### PR TITLE
Disable project search submit / keep back-button history

### DIFF
--- a/run_dir/design/projects.html
+++ b/run_dir/design/projects.html
@@ -177,7 +177,9 @@
 
 <script>
 /* check default checkboxes */
-reset_default_checkboxes();
+if (!$("#Filter :checked").length) {
+  reset_default_checkboxes();
+}
 load_table();
 load_undefined_columns();
 


### PR DESCRIPTION
- Override the default behavior for html form submit to do nothing
- Do not reset filters unless empty
- Perform search on page load

Depends on the browser / environment to cache form data before submit and to restore when using the back-button.  No guarantees, but will not break if cache is reset ie. loading the page in a new tab.
