### PR TITLE
HOTFIX: Check if there are samples before processing them

### DIFF
--- a/status/projects.py
+++ b/status/projects.py
@@ -270,6 +270,8 @@ class ProjectDataHandler(ProjectsBaseDataHandler):
 
         sample_view = self.application.projects_db.view("project/samples")
         samples = sample_view[project].rows[0].value
+        # Not all projects (i.e Pending projects) have samples
+        samples = {} if not samples else samples
         summary_row.value.update(self.sample_progress_rows(samples))
 
         return summary_row.value
@@ -306,7 +308,8 @@ class ProjectSamplesDataHandler(SafeHandler):
         samples = OrderedDict()
         sample_view = self.application.projects_db.view("project/samples")
         result = sample_view[project]
-        samples = result.rows[0].value
+        # Not all projects (i.e Pending projects) have samples!
+        samples = result.rows[0].value if result.rows[0].value else {}
         output = OrderedDict()
         for sample, sample_data in sorted(samples.iteritems(), key=lambda x: x[0]):
             sample_data = self.sample_data(sample_data)
@@ -394,7 +397,7 @@ class LinksDataHandler(SafeHandler):
         p.get(force=True)
 
         links = json.loads(p.udf['Links']) if 'Links' in p.udf else {}
-        
+
         #Sort by descending date, then hopefully have deviations on top
         sorted_links = OrderedDict()
         for k, v in sorted(links.iteritems(), key=lambda t: t[0], reverse=True):


### PR DESCRIPTION
Otherwise Pending projects or any project without samples won't load.

```
Traceback (most recent call last):
  File "/Users/guillem/anaconda/envs/master/lib/python2.7/site-packages/tornado-3.2-py2.7-macosx-10.5-x86_64.egg/tornado/web.py", line 1218, in _when_complete
    callback()
  File "/Users/guillem/anaconda/envs/master/lib/python2.7/site-packages/tornado-3.2-py2.7-macosx-10.5-x86_64.egg/tornado/web.py", line 1239, in _execute_method
    self._when_complete(method(*self.path_args, **self.path_kwargs),
  File "/Users/guillem/repos/status/status/projects.py", line 250, in get
    self.write(json.dumps(self.project_info(project)))
  File "/Users/guillem/repos/status/status/projects.py", line 273, in project_info
    summary_row.value.update(self.sample_progress_rows(samples))
  File "/Users/guillem/repos/status/status/projects.py", line 173, in sample_progress_rows
    for sample_name, sample_data in sample_rows.iteritems():
AttributeError: 'NoneType' object has no attribute 'iteritems'
```
