### PR TITLE
Makes sample table scrollable to handle overflow

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -508,12 +508,14 @@
                   If a sample is named 'Unexptectedbarcode' refers to reads which failed to
                   demultiplex.
                   </p>
-                  <table class="table table-striped" id="sample_table">
-                    <thead id="samples_table_head">
-                    </thead>
-                    <tbody class="list" id="samples_table_body">
-                    </tbody>
-                  </table>
+                  <div class="scrollable">
+                    <table class="table table-striped" id="sample_table">
+                      <thead id="samples_table_head">
+                      </thead>
+                      <tbody class="list" id="samples_table_body">
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
If someone, for some reason, choses to display all columns in the sample table in PV it will now be scrollable.
The accordions or possibly nav tabs made overflow hidden
