### PR TITLE
fixed the case where filenames contain stupid spaces

### DIFF
--- a/status/projects.py
+++ b/status/projects.py
@@ -10,6 +10,7 @@ import requests
 import re
 import paramiko
 import base64
+import urllib
 
 from itertools import ifilter
 from collections import OrderedDict
@@ -329,7 +330,8 @@ class CaliperImageHandler(SafeHandler):
         """returns a base64 string of the caliper image aksed"""
         pattern=re.compile("^sftp://([a-z\.]+)(.+)")
         host=pattern.search(url).group(1)
-        uri=pattern.search(url).group(2)
+        uri=urllib.unquote(pattern.search(url).group(2))
+
 
         try:
             transport=paramiko.Transport(host)
@@ -344,6 +346,7 @@ class CaliperImageHandler(SafeHandler):
             returnHTML=json.dumps(encoded_string)
             return returnHTML
         except Exception, message:
+            print message
             return("Error fetching caliper images")
 
 


### PR DESCRIPTION
So what happens is that when the filename contains spaces, the lims api gives me an uri with %20's instead of spaces, and the sftp get fails because no such file exists. Now, I decode the url properly. And I also print what the error is, should it happen.
