### PR TITLE
Added URL handler to serve static QC_reports files

### DIFF
--- a/status/util.py
+++ b/status/util.py
@@ -163,14 +163,6 @@ class PagedQCDataHandler(SafeHandler):
         return sample_list
 
 
-class NoCacheStaticFileHandler(tornado.web.StaticFileHandler):
-    """ Serves up static files without any tornado caching.
-    https://gist.github.com/omarish/5499385
-    """
-    def set_extra_headers(self, path):
-        self.set_header("Cache-control", "no-cache")
-
-
 ########################
 # Other useful classes #
 ########################

--- a/status_app.py
+++ b/status_app.py
@@ -131,7 +131,7 @@ class Application(tornado.web.Application):
             ("/q30", Q30Handler),
             ("/picea", PiceaHandler),
             ("/qc/([^/]*)$", SampleQCSummaryHandler),
-            (r"/qc_reports/(.*)", NoCacheStaticFileHandler, {"path": 'qc_reports'}),
+            (r"/qc_reports/(.*)", tornado.web.StaticFileHandler, {"path": 'qc_reports'}),
             ("/quotas", QuotasHandler),
             ("/quotas/(\w+)?", QuotaHandler),
             ("/phix_err_rate", PhixErrorRateHandler),


### PR DESCRIPTION
New URL rewriting to allow the `qc_report` files that guillermo has copied across to be visible as static files in the browser. Now that I can see them, I can start to write the QC-tool which will build the URLs to load them.
