### PR TITLE
handles the case where the lims can't be queried

### DIFF
--- a/status/projects.py
+++ b/status/projects.py
@@ -376,6 +376,11 @@ class ProjectSamplesHandler(SafeHandler):
             summary=summaries[0]
         except IndexError:
            print "No project summary for project {}".format(project) 
+        except ConnectionError:
+            print "Error Accessing the lims"
+            return limsdata
+
+
         else:
             for field,value in summary.udf.items():
                 limsdata['summary'][field]=value


### PR DESCRIPTION
Sometimes, we can't query the lims. Instead of letting an error being raised, this will handle it. 

This part will be reverted to the old way of getting the fields next week anyway, but this should resolve the errors.
