### PR TITLE
Added some error handling to the Project Samples page

### DIFF
--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -570,7 +570,7 @@ function load_samples_table() {
     var size = 0;
     
     // No samples
-    if(Object.getOwnPropertyNames(data).length == 0){
+    if(Object.getOwnPropertyNames(samples_data).length == 0){
       $('#tab_samples_content').html('<div class="alert alert-info">Project <strong>'+project+'</strong> does not yet have any samples..</div>');
       return false;
     }


### PR DESCRIPTION
- `console.log` calls when any of the AJAX calls fail
- **Project Not Found** page display when no project is returned, instead of just an empty template
  - _eg._ https://genomics-status-stage.scilifelab.se/project/this_project_doesn't_exist
- **No Samples Found** in the samples tab instead of an empty table if no samples..
  - _eg._ https://genomics-status-stage.scilifelab.se/project/P920
