### PR TITLE
Bug Fix - lanes ordered not displayed

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -144,7 +144,7 @@ Description: Details page for a single project
               <tr><td>% phiX</td><td id="phix_spike-in_percent"></td></tr>
               <tr><td>Low Diversity</td><td id="low_diversity"></td></tr>
               <tr><td>Custom Primer</td><td id="custom_primer"></td></tr>
-              <tr><td>Lanes Ordered</td><td><span class="badge" id="sequence_units_ordered_lanes"></span></td></tr>
+              <tr><td>Lanes Ordered</td><td><span class="badge" id="sequence_units_ordered_(lanes)"></span></td></tr>
             </tbody>
           </table>
         </div>


### PR DESCRIPTION
A leftover bug from when I was trying to make IDs with brackets work - the template was missing the brackets in the ID. Tested locally and seems to work now.
