### PR TITLE
Improved the display of new running notes.

### DIFF
--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -348,8 +348,15 @@ $("#running_notes_form").submit( function(e) {
         console.log(errorThrown);
       },
       success: function(data, textStatus, xhr) {
-        load_running_notes();
+        // Clear the text box
         $('#new_note_text').val('');
+        // Create a new running note and slide it in..
+        var now = new Date();
+        $('<div class="panel panel-success"><div class="panel-heading">'+
+              '<a href="mailto:' + data['email'] + '">'+data['user']+'</a> - '+
+              now.toDateString() + ', ' + now.toLocaleTimeString(now)+
+            '</div><div class="panel-body"><pre>'+make_project_links(data['note'])+
+            '</pre></div></div>').hide().prependTo('#running_notes_panels').slideDown();
       }
     });
   }
@@ -1139,9 +1146,7 @@ function make_timescale_bar(tsid, include_orderdates){
 			$(tsid).append('<div class="timelineTarget" style="left:'+percent+'%;" data-datestamp="'+rawdate+'" data-toggle="tooltip" data-placement="bottom" title="'+rawdate+'<br><strong>'+names.join('</strong><br><strong>')+'</strong>'+diffdaystext+'"><div class="timelineTick" style="background-color:'+thiscol+';"></div></div>');
       
       // Coloured borders next to dates in table
-      if(thiscol !== cols[0] && thiscol !== cols[1]){
-        $(':contains('+rawdate+')').filter(function(){ return $(this).children().length === 0;}).css('border-right', '2px solid '+thiscol).css('padding-right','5px');
-      }
+      $(':contains('+rawdate+')').filter(function(){ return $(this).children().length === 0;}).css('border-right', '2px solid '+thiscol).css('padding-right','5px');
 		});
 	}
 	

--- a/status/projects.py
+++ b/status/projects.py
@@ -425,16 +425,15 @@ class RunningNotesDataHandler(SafeHandler):
             self.set_status(400)
             self.finish('<html><body>No project id or note parameters found</body></html>')
         else:
+            newNote = {'user': user, 'email': email, 'note': note}
             p = Project(lims, id=project)
             p.get(force=True)
             running_notes = json.loads(p.udf['Running Notes']) if 'Running Notes' in p.udf else {}
-            running_notes[str(datetime.datetime.now())] = {'user': user,
-                                                           'email': email,
-                                                           'note': note}
+            running_notes[str(datetime.datetime.now())] = newNote
             p.udf['Running Notes'] = json.dumps(running_notes)
             p.put()
             self.set_status(201)
-            self.write('{}')
+            self.write(json.dumps(newNote))
 
 
 class LinksDataHandler(SafeHandler):


### PR DESCRIPTION
Running note handler now returns the content of the newly inserted running note. This is taken by the page and inserted smoothly into the top of the list of running notes. Previously, all running notes were cleared and then loaded again, which made the page jump if you had scrolled. Now it's inserted at the top of the existing list, so the page doesn't jump. And it's now green :)

![image](https://cloud.githubusercontent.com/assets/465550/5042843/b6e355fe-6bdd-11e4-83e5-1e08261d0539.png)

Also added small coloured bars next to previously non-included dates.

![image](https://cloud.githubusercontent.com/assets/465550/5042848/cc0c2f32-6bdd-11e4-856a-4358c0969e95.png)

Running at http://130.229.42.149:9761/project/P472 for testing
