### PR TITLE
Added functionality for a warning if a project is old.

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -49,23 +49,38 @@ Description: Details page for a single project
     <h4>Project Timeline</h4>
     <dl class="dl-horizontal">
       <dt><abbr data-toggle="tooltip" title="From <em>Open date</em><br>until close / today">Days in Production</abbr></dt>
-        <dd id="days_in_production">-</dd>
-      <dt>Open date</dt>									<dd><span class="rawdate" id="open_date">-</span></dd>
+      <dd id="days_in_production">-</dd>
+      
+      <dt>Open date</dt>
+      <dd>
+        <span class="rawdate" id="open_date">-</span>
+        <span class="label label-danger" id="old_project_warning" data-toggle="tooltip" style="display:none;">Warning - Old Project!</span>
+      </dd>
+      
       <dt><abbr data-toggle="tooltip" title="First Initial Quality Control">QC</abbr> Start Date</dt>
-				<dd><span class="rawdate" id="first_initial_qc_start_date">-</span></dd>
+			<dd><span class="rawdate" id="first_initial_qc_start_date">-</span></dd>
+      
       <dt>Queue Date</dt>
-      	<dd><span class="rawdate" id="queued">-</span>&nbsp; <span id="signature_queued" class="upperCase label label-default"></span></dd>
+      <dd><span class="rawdate" id="queued">-</span>&nbsp; <span id="signature_queued" class="upperCase label label-default"></span></dd>
+      
       <dt>Library Prep Start</dt>					<dd><span class="rawdate" id="library_prep_start">-</span></dd>
       <dt>QC Library Finished</dt>				<dd><span class="rawdate" id="qc_library_finished">-</span></dd>
       <dt>Sequencing Start</dt>						<dd><span class="rawdate" id="sequencing_start_date">-</span></dd>
+      
       <dt>All Samples Sequenced</dt>
-      	<dd><span class="rawdate" id="all_samples_sequenced">-</span>&nbsp; <span id="signature_all_samples_sequenced" class="upperCase label label-default"></span></dd>
+      <dd><span class="rawdate" id="all_samples_sequenced">-</span>&nbsp; <span id="signature_all_samples_sequenced" class="upperCase label label-default"></span></dd>
+      
       <dt>All Raw Data Delivered</dt>
-	      <dd><spanclass="rawdate"  id="all_raw_data_delivered">-</span>&nbsp; <span id="signature_all_raw_data_delivered" class="label label-default"></span></dd>
+	    <dd><spanclass="rawdate"  id="all_raw_data_delivered">-</span>&nbsp; <span id="signature_all_raw_data_delivered" class="label label-default"></span></dd>
+      
       <dt class="bp-dates"><abbr data-toggle="tooltip" title="Best Practice">BP</abbr> Analysis Completed</dt>
-	      <dd class="bp-dates"><span class="rawdate" id="best_practice_analysis_completed">-</span>&nbsp; <span id="signature_best_practice_analysis_completed" class="upperCase label label-default"></span></dd>
-      <dt>Close Date</dt>									<dd><span class="rawdate" id="close_date">-</span></dd>
-      <dt class="aborted-dates">Aborted</dt><dd><span class="aborted-dates rawdate" id="aborted">-</span></dd>
+	    <dd class="bp-dates"><span class="rawdate" id="best_practice_analysis_completed">-</span>&nbsp; <span id="signature_best_practice_analysis_completed" class="upperCase label label-default"></span></dd>
+      
+      <dt>Close Date</dt>
+      <dd><span class="rawdate" id="close_date">-</span></dd>
+      
+      <dt class="aborted-dates">Aborted</dt>
+      <dd><span class="aborted-dates rawdate" id="aborted">-</span></dd>
     </dl>
   </div>
 

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -518,6 +518,9 @@ function load_all_udfs(){
 		// Make the cool timescale bar if we can
 		make_timescale();
     
+    // Warn users about old projects
+    old_project_warning('2010-07-1');
+    
     // Check the height of the user comment
     check_fade_height();
   }).fail(function( jqxhr, textStatus, error ) {
@@ -1150,4 +1153,15 @@ function make_timescale_bar(tsid, include_orderdates){
 		});
 	}
 	
+}
+
+
+// Warn users about old projects
+function old_project_warning(warndate_raw){
+  var openDate = new Date($('#open_date').text());
+  var warnDate = new Date(warndate_raw);
+  if(openDate.getTime() < warnDate.getTime()){
+    $('#old_project_warning').show();
+    $('#old_project_warning').attr('title', 'This project was created before '+warndate_raw+'.<br>Genomics Status may be inaccruate.');
+  }
 }


### PR DESCRIPTION
Added simple functionality to check the open date and show a warning if a project is old. Currently not used, but ready to implement if and when it's needed.
- Change the threshold for which projects should be warned with: `old_project_warning('<date>');` on L522
- Change the message on L1165
