### PR TITLE
Added JS error catch when adding links to a project

### DIFF
--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -232,10 +232,16 @@ $("#link_form").submit(function(e) {
       url: '/api/v1/links/' + project,
       dataType: 'json',
       data: {'type': type, 'title': title, 'url':url, 'desc':desc},
+    }).done(function(){
+      //Clear form fields
+      $('#new_link_type, #new_link_title, #new_link_url, #new_link_desc').val("");
+      load_links();
+    }).fail(function( jqxhr, textStatus, error ) {
+        var err = textStatus + ", " + error;
+        console.log( "Couldn't insert running note: " + err );
+        alert( "Error - Couldn't insert running note..  Is there something weird about this project in the LIMS?" );
     });
-    //Clear form fields
-    $('#new_link_type, #new_link_title, #new_link_url, #new_link_desc').val("");
-    load_links();
+    
   }
   else if(!$.browser.chrome) {
     //Non-chrome users might not get a useful html5 message


### PR DESCRIPTION
The page was failing silently when adding a link to a project didn't work - the form cleared and the links reloaded as they should do, but without the new link.

Now, if the API returns a failure the user at least gets a pop up saying so..
