### PR TITLE
Removed unused logic from Pending Review parser

### DIFF
--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -499,18 +499,8 @@ function load_all_udfs(){
 
       // Create the links for review and display the banner
       else if (prettify(key) == 'pending_reviews'){
-        review_links = '';
-        if($.isArray(value)){
-          $.each(value, function(index, limsid){
-              review_links += "<a href='https://genologics.scilifelab.se:8443/clarity/work-complete/"+limsid+"'>Go to the Lims Step</a> ";
-          });
-        } else if (value.substring(0, 2) == '<a'){
-          review_links = value;
-        }
-        if(review_links.length > 0){
-          $("#review_ids").html(review_links);
-          $("#review_alert").show(); 
-        }
+        $("#review_ids").html(value);
+        $("#review_alert").show(); 
       }
       
       // Pass / Fail sample counts


### PR DESCRIPTION
Follow on from the recent hotfix. Talking to @Galithil it sounds like this front end code wasn't updated when the API changed. Unused logic now removed.