### PR TITLE
Fixing alert when inserting links

### DIFF
--- a/run_dir/design/workset_samples.html
+++ b/run_dir/design/workset_samples.html
@@ -21,9 +21,9 @@ Description: Shows information about a specific workset
     <div id="modal_plate" class="modal fade" >
         <div class="plate_modal modal-dialog"> 
              <div class="modal-content">
-                <input type="button" Onclick="updatePlate('library')" value="library" />
-                <input type="button" Onclick="updatePlate('rec_ctrl')" value="Reception Control" />
-                <input type="button" Onclick="updatePlate('seq')" value="Sequencing" />
+                <input type="button" Onclick="updatePlate('rec_ctrl')" value=" Reception Control " />
+                <input type="button" Onclick="updatePlate('library')" value=" Library Validation " />
+                <input type="button" Onclick="updatePlate('seq')" value=" Sequencing" />
                 <canvas id="myCanvas" width="1278" height="860" style="border:1px solid #000000;">
                 </canvas>
             </div>

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -231,15 +231,15 @@ $("#link_form").submit(function(e) {
       type: 'POST',
       url: '/api/v1/links/' + project,
       dataType: 'json',
-      data: {'type': type, 'title': title, 'url':url, 'desc':desc},
+      data: {'type': type, 'title': title, 'url':url, 'desc':desc}
     }).done(function(){
       //Clear form fields
       $('#new_link_type, #new_link_title, #new_link_url, #new_link_desc').val("");
       load_links();
     }).fail(function( jqxhr, textStatus, error ) {
         var err = textStatus + ", " + error;
-        console.log( "Couldn't insert running note: " + err );
-        alert( "Error - Couldn't insert running note..  Is there something weird about this project in the LIMS?" );
+        console.log( "Couldn't insert link: " + err );
+        alert( "Error - Couldn't insert link ..  Is there something weird about this project in the LIMS?" );
     });
     
   }

--- a/status/projects.py
+++ b/status/projects.py
@@ -474,7 +474,7 @@ class LinksDataHandler(SafeHandler):
         url = self.get_argument('url', '')
         desc = self.get_argument('desc','')
 
-        if not type or not title:
+        if not a_type or not title:
             self.set_status(400)
             self.finish('<html><body>Link title and type is required</body></html>')
         else:
@@ -490,6 +490,9 @@ class LinksDataHandler(SafeHandler):
             p.udf['Links'] = json.dumps(links)
             p.put()
             self.set_status(200)
+            #ajax cries if it does not get anything back
+            self.set_header("Content-type", "application/json")
+            self.finish(json.dumps(links))
 
 
 class ProjectTicketsDataHandler(SafeHandler):


### PR DESCRIPTION
So if you send back a 200 with no content, ajax assumes that something failed. So I send back content now, even if it is not used. It could, though, because we could reload the links with what is sent back instead of querying __again__. But that takes care of the most important part. 