### PR TITLE
Fixed: non-standard datestrings in running notes and links

### DIFF
--- a/run_dir/static/js/links.js
+++ b/run_dir/static/js/links.js
@@ -18,7 +18,9 @@ function load_links() {
   $.getJSON(link_url, function(data) {
     $.each(data, function(key, link) {
       var link_href = link['url'] === "" ? "" : (' href="' + link['url'] + '"');
-			var date = new Date(key);
+      var date = key.replace(/-/g, '/');
+      date = date.replace(/\.\d{6}/, '');
+      date = new Date(date);
       $("#existing_links").append('<div class="link_wrapper"><div class="col-sm-8 col-sm-offset-2">'+
 						'<div class="media"><a class="media-left"'+link_href+'>'+
 							'<span style="font-size:18px;" class="glyphicon glyphicon-'+link_icon[link['type']]+'"></span>'+

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -17,7 +17,9 @@ function load_running_notes(wait) {
   $("#running_notes_panels").empty();
   $.getJSON(note_url, function(data) {
     $.each(data, function(date, note) {
-      var date = new Date(date);
+      var date = date.replace(/-/g, '/');
+      date = date.replace(/\.\d{6}/, '');
+      date = new Date(date);
       if(date > new Date('2015-01-01')){
         noteText = make_markdown(note['note']);
       } else {


### PR DESCRIPTION
This should help with Safari / Firefox compatibility:
new Date("YYYY/MM/DD HH:MM:SS") **good**