### PR TITLE
Quotas updates

### DIFF
--- a/run_dir/design/index.html
+++ b/run_dir/design/index.html
@@ -69,20 +69,22 @@
 
 <!-- sparkline plots table -->
 <div class="row">
-	<div class="col-lg-4">
+	<div class="col-lg-6">
 		<h3>Storage Usage</h3>
 		<table id="project_quotas" class="table table-bordered">
 		    <thead>
 		        <tr>
-		            <th>UPPMAX Project</th>
-		            <th>Storage usage</th>
+		            <th>Project</th>
+		            <th>Disk Usage</th>
+		            <th>Nobackup Disk</th>
+		            <th>CPU Hours</th>
 		        </tr>
 		    </thead>
 		    <tbody>
 		    </tbody>
 		</table>
 	</div>
-	<div class="col-sm-8">
+	<div class="col-sm-6">
 		<h3>Latest Updated Data</h3>
 		<table class="table table-striped table-bordered" id="update_table">
 			<thead>

--- a/run_dir/design/quota_grid.html
+++ b/run_dir/design/quota_grid.html
@@ -11,6 +11,7 @@ Description: Shows a grid of graphs showing showing storage information
 
 <h1 id="page_title">Storage and CPU quotas used on UPPMAX projects</h1>
 <p>The quota limit is indicated with a dashed red line.</p>
+<p><span id="show_all_text">Showing data from last two months.</span> &nbsp; <button id="show_all_data" class="btn btn-default btn-xs">Show all data</button></p>
 <ul class="quota-nav pagination"></ul>
 <div id="plots"></div>
 

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -40,6 +40,42 @@ multiple places and typically control typography, or other common elements.
 	overflow: hidden;
 }
 
+#project_quotas td {
+  padding: 0;
+}
+#project_quotas td:first-child {
+  padding: 8px;
+}
+#project_quotas .wrapper {
+  display: inline-block;
+  position: relative;
+  height:100%;
+  width:100%;
+  overflow: visible;
+  white-space: nowrap;
+}
+#project_quotas .val {
+  display: block;
+  position: absolute;
+  padding:0;
+  top: 0;
+  left: 0;
+  bottom: 0;
+  z-index:-1;
+  background-color: #ededed;
+}
+#project_quotas .val span {
+  position: absolute;
+  top: 8px; left: 8px;
+}
+#project_quotas .percent {
+  padding: 8px; 
+}
+#project_quotas .q-danger .val { background-color: #f2dede; }
+#project_quotas .q-danger span { color: #a94442; }
+#project_quotas .q-warning .val { background-color: #fcf8e3; }
+#project_quotas .q-warning span { color: #8a6d3b; }
+
 
 /*
 === Typography ===

--- a/run_dir/static/js/quota.js
+++ b/run_dir/static/js/quota.js
@@ -5,6 +5,31 @@ $(document).ready(function(){
        $('.highlighted').removeClass('highlighted');
        $(target).addClass('highlighted');
     });
+    
+    // Reset x-min to show all data
+    $('#show_all_data').click(function(){
+        var d = null;
+        if($(this).text() == 'Show all data'){
+            $('#show_all_text').text('Showing all data.');
+            $(this).text('Show last two months');
+        } else {
+            // Get timestamp for 2 months ago
+            d = new Date();
+            d.setMonth(d.getMonth() - 2);
+            d.setHours(0,0,0);
+            d = d.getTime();
+            $('#show_all_text').text('Showing data from last two months.');
+            $(this).text('Show all data');
+        }
+        
+        $('.quota_plot, .cpu_plot').each(function(){
+            try {
+                $(this).highcharts().xAxis[0].update({min: d});
+            } catch(err) {
+                console.log('Setting limits for "'+$(this).attr('id')+'" didn\'t work - probably not yet loaded.');
+            }
+        });
+    });
 
 
 
@@ -27,9 +52,9 @@ $(document).ready(function(){
             $("#plots").append('\
             <div class="row" id=' + project_id + '> \
                 <h2>' + project_id + '</h2> \
-                <div class="col-md-4" id="quota_' + project_id + '"></div> \
-                <div class="col-md-4" id="quota_' + project_id + '_nobackup"></div> \
-                <div class="col-md-4" id="cpu_' + project_id + '"></div> \
+                <div class="col-md-4 quota_plot" id="quota_' + project_id + '"></div> \
+                <div class="col-md-4 quota_plot" id="quota_' + project_id + '_nobackup"></div> \
+                <div class="col-md-4 cpu_plot" id="cpu_' + project_id + '"></div> \
             </div>');
 
             // fill the data html
@@ -44,6 +69,12 @@ $(document).ready(function(){
 });
 
 function get_disk_quota(project_id) {
+    // Get timestamp for 2 months ago
+    var d = new Date();
+    d.setMonth(d.getMonth() - 2);
+    d.setHours(0,0,0);
+    d = d.getTime();
+    
     $.getJSON("/api/v1/quotas/" + project_id, function(api_data) {
         // Massage the data
         var raw_data = api_data[0]["data"];
@@ -73,7 +104,8 @@ function get_disk_quota(project_id) {
             legend: { enabled: false },
             xAxis: {
                 title: { text: 'Date' },
-                type: 'datetime'
+                type: 'datetime',
+                min: d
             },
             yAxis: {
                 min: 0,
@@ -101,11 +133,15 @@ function get_disk_quota(project_id) {
                 }
             ]
         });
-
-
     });
 }
 function get_cpu_hours(project_id) {
+    // Get timestamp for 2 months ago
+    var d = new Date();
+    d.setMonth(d.getMonth() - 2);
+    d.setHours(0,0,0);
+    d = d.getTime();
+    
     $.getJSON("/api/v1/cpu_hours/" + project_id, function(api_data) {
         // Massage the data
         var raw_data = api_data[0]["data"];
@@ -124,7 +160,6 @@ function get_cpu_hours(project_id) {
             if(max_value < point.limit) { max_value = point.limit; }
         });
         // Plot the data
-
         $('#cpu_'+project_id).highcharts({
             chart: {
                 zoomType: 'x',
@@ -134,7 +169,8 @@ function get_cpu_hours(project_id) {
             legend: { enabled: false },
             xAxis: {
                 title: { text: 'Date' },
-                type: 'datetime'
+                type: 'datetime',
+                min: d
             },
             yAxis: {
                 min: 0,
@@ -162,8 +198,6 @@ function get_cpu_hours(project_id) {
                 }
             ]
         });
-
-
     });
 
 }


### PR DESCRIPTION
* Quotas page now shows data from just the last 2 months only by default
* New button on quotas page toggles between all data / last two months
* New quotas table on homepage
  * Shows current status in bars instead of sparkline plot

Requires change to `settings.yaml` - removing the `nobackup` projects from `uppmax_projects`.

Deploying on stage now..