### PR TITLE
New 'mismatches' feature on flowcells page (unknown barcodes)

### DIFF
--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -487,6 +487,11 @@ td.progress {
   background-color: #f2dede;
   border: 1px solid #ebccd1;
 }
+.undetermined-warning {
+  color: #8a6d3b;
+  background-color: #fcf8e3;
+  border-color: #faebcc;
+}
 
 .thousand_group {
   margin-left:4px;

--- a/run_dir/static/js/flowcell_samples.js
+++ b/run_dir/static/js/flowcell_samples.js
@@ -209,7 +209,7 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
                             if(bc !== 'unknown'){
                                 var mm = 0;
                                 for (var i = 0, len = unmatched.length; i < len; i++) {
-                                    if(unmatched[i] != bc[i] || unmatched[i] != 'N' || unmatched[i] != 'N'){
+                                    if(unmatched[i] != bc[i] && unmatched[i] != 'N' && bc[i] != 'N'){
                                         mm += 1;
                                     }
                                 }

--- a/run_dir/static/js/flowcell_samples.js
+++ b/run_dir/static/js/flowcell_samples.js
@@ -167,7 +167,13 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
             $('#lane_'+lid).append(lbody);
             if ('undetermined' in data) {
                 var ludtable='<table class="undetermined" id="table_ud_lane_' + lid + '" style="display:none;">';
-                ludtable += "<tr><th>Total</th><th>"+nice_numbers(total_undetermined_claster_number)+"</th><th>(100%)</span></th></tr>";
+                ludtable += "<tr><th>Total</th><th>"+nice_numbers(total_undetermined_claster_number)+"</th><th>(100%)</span></th>";
+                for (var s in data['lane'][lid]){
+                    if(data['lane'][lid][s]['barcode'] !== 'unknown'){
+                        ludtable += '<th>'+data['lane'][lid][s]['barcode']+' mismatches</th>';
+                    }
+                }
+                ludtable += "</tr>";
 
                 var button='<button id="ud_button_lane_' +lid + '" class="undetermined-btn btn btn-info btn-sm" \
                            type="button" onclick="display_undetermined(' + lid + ')" >Show Undetermined</button>';
@@ -194,7 +200,24 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
                     var percentage = (100 * count/total_undetermined_claster_number).toFixed(2);
 
                     count = nice_numbers(count);
-                    ludtable += "<tr"+hl+"><td><samp>"+unmatched+"</samp></td><td>"+count+'</td><td>('+percentage+"%)</span></td></tr>";
+                    ludtable += "<tr"+hl+"><td><samp>"+unmatched+"</samp></td><td>"+count+'</td><td>('+percentage+"%)</span></td>";
+                    for (var s in data['lane'][lid]){
+                        var bc = data['lane'][lid][s]['barcode'];
+                        if(bc !== 'unknown'){
+                            var mm = 0;
+                            for (var i = 0, len = unmatched.length; i < len; i++) {
+                                if(unmatched[i] != bc[i] && unmatched[i] != 'N' && unmatched[i] != 'N'){
+                                    mm += 1;
+                                }
+                            }
+                            var fr_matched = (unmatched.length - mm)/unmatched.length;
+                            var tdclass = '';
+                            if(fr_matched > 0.6){ tdclass = ' class="undetermined-warning"'; }
+                            if(fr_matched > 0.8){ tdclass = ' class="undetermined-highlight"'; }
+                            ludtable += '<td'+tdclass+'>'+mm+'</td>';
+                        }
+                    }
+                    ludtable += "</tr>";
                 }
                 ludtable+="</dl>";
                 $('#button_lane_'+lid).append(button);

--- a/run_dir/static/js/flowcell_samples.js
+++ b/run_dir/static/js/flowcell_samples.js
@@ -168,9 +168,11 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
             if ('undetermined' in data) {
                 var ludtable='<table class="undetermined" id="table_ud_lane_' + lid + '" style="display:none;">';
                 ludtable += "<tr><th>Total</th><th>"+nice_numbers(total_undetermined_claster_number)+"</th><th>(100%)</span></th>";
-                for (var s in data['lane'][lid]){
-                    if(data['lane'][lid][s]['barcode'] !== 'unknown'){
-                        ludtable += '<th>'+data['lane'][lid][s]['barcode']+' mismatches</th>';
+                if(data['lane'][lid].length <= 10){
+                        for (var s in data['lane'][lid]){
+                        if(data['lane'][lid][s]['barcode'] !== 'unknown'){
+                            ludtable += '<th>'+data['lane'][lid][s]['barcode']+' mismatches</th>';
+                        }
                     }
                 }
                 ludtable += "</tr>";
@@ -201,20 +203,22 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
 
                     count = nice_numbers(count);
                     ludtable += "<tr"+hl+"><td><samp>"+unmatched+"</samp></td><td>"+count+'</td><td>('+percentage+"%)</span></td>";
-                    for (var s in data['lane'][lid]){
-                        var bc = data['lane'][lid][s]['barcode'];
-                        if(bc !== 'unknown'){
-                            var mm = 0;
-                            for (var i = 0, len = unmatched.length; i < len; i++) {
-                                if(unmatched[i] != bc[i] && unmatched[i] != 'N' && unmatched[i] != 'N'){
-                                    mm += 1;
+                    if(data['lane'][lid].length <= 10){
+                        for (var s in data['lane'][lid]){
+                            var bc = data['lane'][lid][s]['barcode'];
+                            if(bc !== 'unknown'){
+                                var mm = 0;
+                                for (var i = 0, len = unmatched.length; i < len; i++) {
+                                    if(unmatched[i] != bc[i] && unmatched[i] != 'N' && unmatched[i] != 'N'){
+                                        mm += 1;
+                                    }
                                 }
+                                var fr_matched = (unmatched.length - mm)/unmatched.length;
+                                var tdclass = '';
+                                if(fr_matched > 0.6){ tdclass = ' class="undetermined-warning"'; }
+                                if(fr_matched > 0.8){ tdclass = ' class="undetermined-highlight"'; }
+                                ludtable += '<td'+tdclass+'>'+mm+'</td>';
                             }
-                            var fr_matched = (unmatched.length - mm)/unmatched.length;
-                            var tdclass = '';
-                            if(fr_matched > 0.6){ tdclass = ' class="undetermined-warning"'; }
-                            if(fr_matched > 0.8){ tdclass = ' class="undetermined-highlight"'; }
-                            ludtable += '<td'+tdclass+'>'+mm+'</td>';
                         }
                     }
                     ludtable += "</tr>";

--- a/run_dir/static/js/flowcell_samples.js
+++ b/run_dir/static/js/flowcell_samples.js
@@ -209,7 +209,7 @@ $.getJSON("/api/v1/flowcell_info2/"+flowcell, function(data) {
                             if(bc !== 'unknown'){
                                 var mm = 0;
                                 for (var i = 0, len = unmatched.length; i < len; i++) {
-                                    if(unmatched[i] != bc[i] && unmatched[i] != 'N' && unmatched[i] != 'N'){
+                                    if(unmatched[i] != bc[i] || unmatched[i] != 'N' || unmatched[i] != 'N'){
                                         mm += 1;
                                     }
                                 }


### PR DESCRIPTION
For lanes with >= 10 barcodes, the flow cells page now has a column showing the number of mismatches for each barcode for each unknown barcode:

![image](https://cloud.githubusercontent.com/assets/465550/11423022/2aec7b56-9441-11e5-9fd4-8d91940f9ae3.png)

If the barcodes are >= 80% matching, the cell is highlighted in red. >= 60% matching cells are highlighted in yellow.

Running on stage: https://genomics-status-stage.scilifelab.se/flowcells/151103_BH5VMNCCXX