### PR TITLE
Fixing library ordering bug

### DIFF
--- a/run_dir/static/js/deliveries.js
+++ b/run_dir/static/js/deliveries.js
@@ -94,17 +94,17 @@ $(document).ready(function() {
               else {                                              project_status = "Closed"; }
             }
             // Only allow ongoing projects to continue
-            if(project_status != 'Ongoing'){
-              $(d['container_id']).append(
-                '<h3><a href="project/'+pid+'" class="bi-project-id">'+pid+'</a>: '+
-                '<span class="bi-project-name">'+pdata[pid]['project_name']+'</span><br>'+
-                '<small><span class="bi-project-application" data-toggle="tooltip" data-delay="500" title="Application">'+pdata[pid]['application']+'</span> &nbsp '+
-                '<span class="bi-project-facility label label-primary" data-toggle="tooltip" data-delay="500" title="Project Facility">'+pdata[pid]['type']+'</span> &nbsp; '+
-                '<span class="bi-project-assigned" data-toggle="tooltip" data-delay="500" title="Bioinfo-responsible">'+pdata[pid]['bioinfo_responsible']+'</span></small></h3>'+
-                '<div class="alert alert-danger"><strong>Error</strong> - Project is not ongoing. '+pid+' is '+project_status+'</div>'
-              );
-              return true;
-            }
+            // if(project_status != 'Ongoing'){
+            //   $(d['container_id']).append(
+            //     '<h3><a href="project/'+pid+'" class="bi-project-id">'+pid+'</a>: '+
+            //     '<span class="bi-project-name">'+pdata[pid]['project_name']+'</span><br>'+
+            //     '<small><span class="bi-project-application" data-toggle="tooltip" data-delay="500" title="Application">'+pdata[pid]['application']+'</span> &nbsp '+
+            //     '<span class="bi-project-facility label label-primary" data-toggle="tooltip" data-delay="500" title="Project Facility">'+pdata[pid]['type']+'</span> &nbsp; '+
+            //     '<span class="bi-project-assigned" data-toggle="tooltip" data-delay="500" title="Bioinfo-responsible">'+pdata[pid]['bioinfo_responsible']+'</span></small></h3>'+
+            //     '<div class="alert alert-danger"><strong>Error</strong> - Project is not ongoing. '+pid+' is '+project_status+'</div>'
+            //   );
+            //   return true;
+            // }
 
             // Main project fields
             var responsible = pdata[pid]['bioinfo_responsible'] == undefined ? '??' : pdata[pid]['bioinfo_responsible'];

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -606,7 +606,7 @@ function load_samples_table() {
             var column_name = column_tuple[0];
             var column_id = column_tuple[1];
             tbl_row += '<td class="' + column_id + '">';
-            var libs = Object.keys(info[column_id]).sort();
+            var libs = Object.keys(info['library_prep']).sort();
             $.each(libs, function(idx, library){
               info_library=info['library_prep'][library];
               info_library[column_id] = round_floats(info_library[column_id], 2);


### PR DESCRIPTION
Fixed bug from recent PR by @Galithil, ordering the libraries in the project samples tab.

Also includes commented out JS for the deliveries page. Doesn't hurt for this to go into production as these pages are not yet operational.