### PR TITLE
Bug fix: code injections in the running notes

### DIFF
--- a/run_dir/static/js/base.js
+++ b/run_dir/static/js/base.js
@@ -208,6 +208,11 @@ function check_img_sources(obj){
   });
 }
 function make_markdown(s){
+  s = s.replace(/&/g, "&amp;")
+         .replace(/</g, "&lt;")
+         .replace(/>/g, "&gt;")
+         .replace(/"/g, "&quot;")
+         .replace(/'/g, "&#039;");
   s = marked(s);
   s = make_project_links(s);
   return '<div class="mkdown">'+s+'</div>';

--- a/run_dir/static/js/base.js
+++ b/run_dir/static/js/base.js
@@ -208,11 +208,7 @@ function check_img_sources(obj){
   });
 }
 function make_markdown(s){
-  s = s.replace(/&/g, "&amp;")
-         .replace(/</g, "&lt;")
-         .replace(/>/g, "&gt;")
-         .replace(/"/g, "&quot;")
-         .replace(/'/g, "&#039;");
+  s = $('<div>').text(s).html();
   s = marked(s);
   s = make_project_links(s);
   return '<div class="mkdown">'+s+'</div>';


### PR DESCRIPTION
that was a funny thing. 

In the running notes I could enter something like
```<button id='test' type='button'>Hack test</button>
<script>
$('#test').on('click', function(e) {
console.log('hack works!');
// you can call here api
// or send thousand emails to everyone@scilifelab.se
// or anything bad whatever you can do with javascript
});
</script>```

and we had a button that was executing whatever stuff you write in the `<script>` block