### PR TITLE
Adding a way to see the instrument logs

### DIFF
--- a/run_dir/design/base.html
+++ b/run_dir/design/base.html
@@ -60,6 +60,7 @@
                         <li><a href="/clusters_per_lane">Clusters per lane</a></li>
                         <li><a href="/reads_total/">Summing Reads</a></li>
                         <li><a href="/proj_meta">Compare Project Meta</a></li>
+                        <li><a href="/instrument_logs">View Instrument Logs</a></li>
                         <li class="depreciated_page divider"></li>
                         <li id="depreciated_header"><a href="#">Depreciated Pages</a></li>
                         <li class="depreciated_page"><a href="/barcode_vs_expected" >Barcode vs Expected</a></li>

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -22,7 +22,7 @@ Description: Shows instrument logs for the given period.default is one week.
     <div class='input-group input-group-sm date' id='datepick2'>
         <input id="inp_date_2" type='text' class="form-control"/><span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span> 
     </div>
-    <button id="submit_interval" class="btn btn-primary">Search</button>
+    <button id="submit_interval" class="btn btn-primary btn-sm">Search</button>
     </form>
 </div>
 <div id="main_table">

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -1,0 +1,56 @@
+{% extends "base.html" %}
+
+<!--
+Template file: instrument_logs.html
+URL: /instrument_logs/[timestamp1]-[timestamp]2
+Title: Instrument Logs
+Description: Shows instrument logs for the given period.default is one week.
+-->
+
+{% block stuff %}
+
+<div id="page_content">
+<h1>Instrument Logs</h1>
+<div id="logs_date" style="margin_bottom:5px;">
+    <p>The default view shows 1 week worth of logs. You can customise the range here :</p>
+    <form class="form-inline">
+        Select logs from 
+        <div class='input-group input-group-sm date' id='datepick1'>
+            <input id="inp_date_1" type='text' class="form-control" /><span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>
+        </div>
+    to
+    <div class='input-group input-group-sm date' id='datepick2'>
+        <input id="inp_date_2" type='text' class="form-control"/><span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span> 
+    </div>
+    <button id="submit_interval" class="btn btn-primary">Search</button>
+    </form>
+</div>
+<div id="main_table">
+<table class="table table-bordered narrow-headers" id="instrument_logs_table">
+    <thead>
+        <th class="col-md-1">Date</th>
+        <th class="col-md-1">Instrument</th>
+        <th class="col-md-10">Message</th>
+    </thead>
+    <tfoot>
+        <th class="col-md-1">Date</th>
+        <th class="col-md-1">Instrument</th>
+        <th class="col-md-10">Message</th>
+    </tfoot>
+    <tbody>
+        {% for onedoc in docs %}
+        <tr>
+            <td class="col-md-1">{{ onedoc.get('timestamp') }}</td>
+            <td class="col-md-1">{{ onedoc.get('instrument_name') }}</td>
+            <td class="col-md-10">{{ onedoc.get('message') }}</td>
+        </tr>
+        {% end %}
+    </tbody>
+</table>
+</div>
+
+
+<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/bootstrap-datepicker.min.js"></script>
+<script src="/static/js/instrument_logs.js"></script>
+{% end %}

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -13,7 +13,7 @@ Description: Shows instrument logs for the given period.default is one week.
 <h1>Instrument Logs</h1>
 <div id="logs_date" style="margin-bottom:15px;">
     <p>The default view shows 1 week worth of logs. You can customise the range here :</p>
-    <form class="form-inline">
+    <form class="form-inline" id="logs_date_form">
         Select logs from 
         <div class='input-group input-group-sm date' id='datepick1'>
             <input id="inp_date_1" type='text' class="form-control" /><span class="input-group-addon"><span class="glyphicon glyphicon-calendar"></span></span>

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -40,7 +40,7 @@ Description: Shows instrument logs for the given period.default is one week.
     <tbody>
         {% for onedoc in docs %}
         <tr>
-            <td class="col-md-1">{{ onedoc.get('timestamp') }}</td>
+            <td class="col-md-1" data-sort="{{ (datetime.datetime.strptime(onedoc.get('timestamp'), "%Y-%m-%dT%H:%M:%S.%f") - datetime.datetime(1970, 1, 1)).total_seconds() }}">{{ datetime.datetime.strptime(onedoc.get('timestamp'), "%Y-%m-%dT%H:%M:%S.%f").strftime("%Y-%m-%d %H:%M:%S") }}</td>
             <td class="col-md-1">{{ onedoc.get('instrument_name') }}</td>
             <td class="col-md-10">{{ onedoc.get('message') }}</td>
         </tr>

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -11,7 +11,7 @@ Description: Shows instrument logs for the given period.default is one week.
 
 <div id="page_content">
 <h1>Instrument Logs</h1>
-<div id="logs_date" style="margin_bottom:5px;">
+<div id="logs_date" style="margin-bottom:15px;">
     <p>The default view shows 1 week worth of logs. You can customise the range here :</p>
     <form class="form-inline">
         Select logs from 

--- a/run_dir/static/js/instrument_logs.js
+++ b/run_dir/static/js/instrument_logs.js
@@ -14,10 +14,8 @@ function init_listjs() {
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');
-    $('#instrument_logs_table_filter').addClass('form-inline pull-right');
-    $("#instrument_logs_table_filter").appendTo("h1");
+    $('#instrument_logs_table_filter').addClass('form-inline pull-left');
     $('#instrument_logs_table_filter label input').appendTo($('#fc_table_filter'));
-    $('#instrument_logs_table_filter label').remove();
     $("#instrument_logs_table_filter input").attr("placeholder", "Search..");
     // Apply the search
     table.columns().every( function () {
@@ -37,10 +35,23 @@ function init_datepickers(){
 function init_submit_button(){
     $('#submit_interval').click(function(e){
      e.preventDefault();
-     var m_d_y=$('#inp_date_1').val().split('/');  
-     var first_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
-     m_d_y=$('#inp_date_2').val().split('/');  
-     var second_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
+     var m_d_y;
+     var first_date;
+     var second_date;
+     var dp=$('#inp_date_1').val();
+     if (dp != ''){
+         m_d_y=dp1.split('/');  
+         first_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
+     }else{
+         first_date=new Date(2016, 01, 01);
+     }
+     dp=$('#inp_date_2').val();
+     if (dp != ''){
+        m_d_y=dp.split('/');  
+        second_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
+     }else{
+        second_date=new Date();
+     }
      var loc="/instrument_logs/"+first_date.getTime()/1000+"-"+second_date.getTime()/1000;
      window.location.href=loc;
 

--- a/run_dir/static/js/instrument_logs.js
+++ b/run_dir/static/js/instrument_logs.js
@@ -14,8 +14,9 @@ function init_listjs() {
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');
-    $('#instrument_logs_table_filter').addClass('form-inline pull-left');
-    $('#instrument_logs_table_filter label input').appendTo($('#fc_table_filter'));
+    $('#instrument_logs_table_filter').addClass('form-inline pull-right');
+    $("#instrument_logs_table_filter").appendTo("#logs_date_form");
+    $('#instrument_logs_table_filter label input').appendTo($('#instrument_logs_table_filter'));
     $("#instrument_logs_table_filter input").attr("placeholder", "Search..");
     // Apply the search
     table.columns().every( function () {
@@ -40,7 +41,7 @@ function init_submit_button(){
      var second_date;
      var dp=$('#inp_date_1').val();
      if (dp != ''){
-         m_d_y=dp1.split('/');  
+         m_d_y=dp.split('/');  
          first_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
      }else{
          first_date=new Date(2016, 01, 01);
@@ -52,7 +53,7 @@ function init_submit_button(){
      }else{
         second_date=new Date();
      }
-     var loc="/instrument_logs/"+first_date.getTime()/1000+"-"+second_date.getTime()/1000;
+     var loc="/instrument_logs/"+Math.round(first_date.getTime()/1000)+"-"+Math.round(second_date.getTime()/1000);
      window.location.href=loc;
 
     

--- a/run_dir/static/js/instrument_logs.js
+++ b/run_dir/static/js/instrument_logs.js
@@ -1,0 +1,54 @@
+
+function init_listjs() {
+    // Setup - add a text input to each footer cell
+    $('#instrument_logs_table tfoot th').each( function () {
+      var title = $('#instrument_logs_table thead th').eq( $(this).index() ).text();
+      $(this).html( '<input size=10 type="text" placeholder="Search '+title+'" />' );
+    } );
+                             
+    var table = $('#instrument_logs_table').DataTable({
+      "paging":false,
+      "info":false,
+      "order": [[ 0, "desc" ]]
+    });
+
+    //Add the bootstrap classes to the search thingy
+    $('div.dataTables_filter input').addClass('form-control search search-query');
+    $('#instrument_logs_table_filter').addClass('form-inline pull-right');
+    $("#instrument_logs_table_filter").appendTo("h1");
+    $('#instrument_logs_table_filter label input').appendTo($('#fc_table_filter'));
+    $('#instrument_logs_table_filter label').remove();
+    $("#instrument_logs_table_filter input").attr("placeholder", "Search..");
+    // Apply the search
+    table.columns().every( function () {
+        var that = this;
+        $( 'input', this.footer() ).on( 'keyup change', function () {
+            that
+            .search( this.value )
+            .draw();
+        } );
+    } );
+}
+
+function init_datepickers(){
+    $('#datepick1').datepicker();
+    $('#datepick2').datepicker();
+}
+function init_submit_button(){
+    $('#submit_interval').click(function(e){
+     e.preventDefault();
+     var m_d_y=$('#inp_date_1').val().split('/');  
+     var first_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
+     m_d_y=$('#inp_date_2').val().split('/');  
+     var second_date=new Date(m_d_y[2], m_d_y[0]-1, m_d_y[1]);
+     var loc="/instrument_logs/"+first_date.getTime()/1000+"-"+second_date.getTime()/1000;
+     window.location.href=loc;
+
+    
+    });
+
+}
+
+init_listjs();
+init_datepickers();
+init_submit_button();

--- a/run_dir/static/js/instrument_logs.js
+++ b/run_dir/static/js/instrument_logs.js
@@ -14,9 +14,9 @@ function init_listjs() {
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');
-    $('#instrument_logs_table_filter').addClass('form-inline pull-right');
+    $('#instrument_logs_table_filter').addClass('form-inline pull-right input-group-sm');
     $("#instrument_logs_table_filter").appendTo("#logs_date_form");
-    $('#instrument_logs_table_filter label input').appendTo($('#instrument_logs_table_filter'));
+    $('#instrument_logs_table_filter label ').html($('#instrument_logs_table_filter input'));
     $("#instrument_logs_table_filter input").attr("placeholder", "Search..");
     // Apply the search
     table.columns().every( function () {

--- a/run_dir/static/js/instrument_logs.js
+++ b/run_dir/static/js/instrument_logs.js
@@ -14,7 +14,8 @@ function init_listjs() {
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');
-    $('#instrument_logs_table_filter').addClass('form-inline pull-right input-group-sm');
+    $('#instrument_logs_table_filter').addClass('form-inline pull-right');
+    $('#instrument_logs_table_filter input').addClass('input-sm');
     $("#instrument_logs_table_filter").appendTo("#logs_date_form");
     $('#instrument_logs_table_filter label ').html($('#instrument_logs_table_filter input'));
     $("#instrument_logs_table_filter input").attr("placeholder", "Search..");

--- a/status/instruments.py
+++ b/status/instruments.py
@@ -36,7 +36,7 @@ class DataInstrumentLogsHandler(SafeHandler):
     def get(self, search_string=None):
         docs=recover_logs(self, search_string)
         self.set_header("Content-type", "application/json")
-        self.write()
+        self.write(json.dumps(docs))
 
 class InstrumentLogsHandler(SafeHandler):
     """ Handles the instrument logs page

--- a/status/instruments.py
+++ b/status/instruments.py
@@ -1,0 +1,51 @@
+
+from status.util import dthandler, SafeHandler
+
+import datetime
+import json
+
+
+
+def recover_logs(handler, search_string=None):
+    if not search_string:
+        #by default, return one week of logs
+        return [row.value for row in handler.application.instrument_logs_db.view("time/last_week")]
+
+    else:
+        #assuming the search string is <timestamp1>-<timestamp2>
+        ts1=search_string.split('-')[0]
+        ts2=search_string.split('-')[1]
+        d1=datetime.datetime.fromtimestamp(int(ts1))
+        d2=datetime.datetime.fromtimestamp(int(ts2))
+
+        valid_rows=[]
+        for row in handler.application.instrument_logs_db.view("time/timestamp"):
+            row_date=datetime.datetime.strptime(row.key, "%Y-%m-%dT%H:%M:%S.%f")
+            if row_date >= d1 and row_date <= d2:
+                valid_rows.append(row.value)
+    
+        return valid_rows
+        
+        
+
+class DataInstrumentLogsHandler(SafeHandler):
+    """ Handles the instrument logs page
+
+    Loaded through /api/v1/instrument_logs/([^/]*)$
+    """
+    def get(self, search_string=None):
+        docs=recover_logs(self, search_string)
+        self.set_header("Content-type", "application/json")
+        self.write()
+
+class InstrumentLogsHandler(SafeHandler):
+    """ Handles the instrument logs page
+
+    Loaded through /instrument_logs/([^/]*)$
+    """
+    def get(self, search_string=None):
+        docs=recover_logs(self, search_string)
+        t = self.application.loader.load("instrument_logs.html")
+        self.write(t.generate(docs=docs,gs_globals=self.application.gs_globals))
+
+

--- a/status_app.py
+++ b/status_app.py
@@ -26,6 +26,7 @@ from status.cpu_hours import CPUHoursDataHandler
 from status.flowcells import FlowcellDataHandler, FlowcellDemultiplexHandler, FlowcellHandler, FlowcellLinksDataHandler, \
     FlowcellNotesDataHandler, FlowcellQ30Handler, FlowcellQCHandler, FlowcellsDataHandler, FlowcellSearchHandler, \
     FlowcellsHandler, FlowcellsInfoDataHandler, OldFlowcellsInfoDataHandler, ReadsTotalHandler
+from status.instruments import InstrumentLogsHandler, DataInstrumentLogsHandler
 from status.phix_err_rate import PhixErrorRateDataHandler, PhixErrorRateHandler
 from status.production import DeliveredMonthlyDataHandler, DeliveredMonthlyPlotHandler, DeliveredQuarterlyDataHandler, \
     DeliveredQuarterlyPlotHandler, ProducedMonthlyDataHandler, ProducedMonthlyPlotHandler, ProducedQuarterlyDataHandler, \
@@ -112,6 +113,7 @@ class Application(tornado.web.Application):
             ("/api/v1/instrument_error_rates", InstrumentErrorrateDataHandler),
             ("/api/v1/instrument_error_rates.png",
                 InstrumentErrorratePlotHandler),
+            ("/api/v1/instrument_logs", DataInstrumentLogsHandler),
             ("/api/v1/instrument_unmatched", InstrumentUnmatchedDataHandler),
             ("/api/v1/instrument_unmatched.png", InstrumentUnmatchedPlotHandler),
             ("/api/v1/instrument_yield", InstrumentYieldDataHandler),
@@ -173,6 +175,8 @@ class Application(tornado.web.Application):
             ("/clusters_per_lane", ClustersPerLaneHandler),
             ("/flowcells", FlowcellsHandler),
             ("/flowcells/([^/]*)$", FlowcellHandler),
+            ("/instrument_logs",InstrumentLogsHandler),
+            ("/instrument_logs/([^/]*)$", InstrumentLogsHandler),
             ("/q30", Q30Handler),
             ("/qc/([^/]*)$", SampleQCSummaryHandler),
             (r"/qc_reports/(.*)", SafeStaticFileHandler, {"path": 'qc_reports'}),
@@ -206,17 +210,18 @@ class Application(tornado.web.Application):
         # Global connection to the database
         couch = Server(settings.get("couch_server", None))
         if couch:
-            self.uppmax_db = couch["uppmax"]
             self.bioinfo_db = couch["bioinfo_analysis"]
-            self.samples_db = couch["samples"]
-            self.projects_db = couch["projects"]
-            self.flowcells_db = couch["flowcells"]
-            self.x_flowcells_db = couch["x_flowcells"]
-            self.gs_users_db = couch["gs_users"]
             self.cronjobs_db = couch["cronjobs"]
-            self.suggestions_db = couch["suggestion_box"]
-            self.worksets_db = couch["worksets"]
+            self.flowcells_db = couch["flowcells"]
+            self.gs_users_db = couch["gs_users"]
+            self.instrument_logs_db = couch["instrument_logs"]
+            self.projects_db = couch["projects"]
+            self.samples_db = couch["samples"]
             self.server_status_db = couch['server_status']
+            self.suggestions_db = couch["suggestion_box"]
+            self.uppmax_db = couch["uppmax"]
+            self.worksets_db = couch["worksets"]
+            self.x_flowcells_db = couch["x_flowcells"]
         else:
             print settings.get("couch_server", None)
             raise IOError("Cannot connect to couchdb");
@@ -304,6 +309,7 @@ class Application(tornado.web.Application):
             tornado.autoreload.watch("design/flowcell_samples.html")
             tornado.autoreload.watch("design/flowcells.html")
             tornado.autoreload.watch("design/index.html")
+            tornado.autoreload.watch("design/instrument_logs.html")
             tornado.autoreload.watch("design/phix_err_rate.html")
             tornado.autoreload.watch("design/production.html")
             tornado.autoreload.watch("design/proj_meta_compare.html")

--- a/status_app.py
+++ b/status_app.py
@@ -114,6 +114,7 @@ class Application(tornado.web.Application):
             ("/api/v1/instrument_error_rates.png",
                 InstrumentErrorratePlotHandler),
             ("/api/v1/instrument_logs", DataInstrumentLogsHandler),
+            ("/api/v1/instrument_logs/([^/]*)$", DataInstrumentLogsHandler),
             ("/api/v1/instrument_unmatched", InstrumentUnmatchedDataHandler),
             ("/api/v1/instrument_unmatched.png", InstrumentUnmatchedPlotHandler),
             ("/api/v1/instrument_yield", InstrumentYieldDataHandler),


### PR DESCRIPTION
So, now, we have a way to send messages from the robots directly to statusdb. The only thing missing is a way to visualize them, and this is what this is about.

https://genomics-status-stage.scilifelab.se/instrument_logs for a nice interface

https://genomics-status-stage.scilifelab.se/api/v1/instrument_logs/ for json

It's also possible to request logs between two timestamps (for both calls) like so : 
https://genomics-status-stage.scilifelab.se/api/v1/instrument_logs/1446786800-1456786800

Any comments ?