### PR TITLE
Fixed table column headers on the homepage

### DIFF
--- a/run_dir/design/index.html
+++ b/run_dir/design/index.html
@@ -75,9 +75,9 @@
 		    <thead>
 		        <tr>
 		            <th>Project</th>
-		            <th>Disk (Used / Free)</th>
-		            <th>Nobackup (Used / Free)</th>
-		            <th>CPU (Used / Free)</th>
+		            <th>Disk (Used / Quota)</th>
+		            <th>Nobackup (Used / Quota)</th>
+		            <th>CPU (Used / Quota)</th>
 		        </tr>
 		    </thead>
 		    <tbody>
@@ -100,8 +100,8 @@
 			<thead>
 				<tr>
 					<th>Server</th>
-          <th>Instrument</th>
-					<th>Disk (Used / Free)</th>
+					<th>Instrument</th>
+					<th>Disk (Used / Quota)</th>
 				</tr>
 			</thead>
 			<tbody>


### PR DESCRIPTION
Currently the homepage says `(Used / Free)`, but this is incorrect. The numbers show the amount used and the total quota available. Updated the labels.