### PR TITLE
Deliveries: replace links to flowcells with long id

### DIFF
--- a/run_dir/design/bioinfo_tab/run_lane_sample_view.html
+++ b/run_dir/design/bioinfo_tab/run_lane_sample_view.html
@@ -85,7 +85,7 @@
           <td class="bioinfo-status-expand"><a href="#bioinfo-fc-{{ flowcell_id }}" class="bioinfo-expand">
             <span class="glyphicon glyphicon-chevron-right"></span></a></td>
           <td></td>
-          <td><samp><a href="/flowcells/{{ flowcell_id.split('_')[0] }}_{{ flowcell_id.split('_')[-1] }}">{{ flowcell_id }}</a></samp></td>
+          <td><samp><a href="/flowcells/{{ flowcell_id }}">{{ flowcell_id }}</a></samp></td>
           <td class="bioinfo-status-runstate"><span class="label {{ status_css.get(flowcell['flowcell_status'], 'label-default') }}">{{ flowcell['flowcell_status'] }}</span></td>
           <td class="bioinfo-status-row ?"><span class="glyphicon glyphicon-arrow-right"></span></td>
           <td class="bioinfo-status-qc undemultiplexedreads unknown">?</td>

--- a/run_dir/design/bioinfo_tab/sample_run_lane_view.html
+++ b/run_dir/design/bioinfo_tab/sample_run_lane_view.html
@@ -129,7 +129,7 @@
             <td></td>
             <td class="bioinfo-status-expand"><a href="#bioinfo-fc-{{ sample_id }}-{{ flowcell_id }}" class="bioinfo-expand">
               <span class="glyphicon glyphicon-chevron-right"></span></a></td>
-            <td><samp><a href="/flowcells/{{ flowcell_id.split('_')[0] }}_{{ flowcell_id.split('_')[-1] }}">{{ flowcell_id }}</a></samp></td>
+            <td><samp><a href="/flowcells/{{ flowcell_id }}">{{ flowcell_id }}</a></samp></td>
             <td class="bioinfo-status-runstate"><span class="label {{ status_css.get(flowcell['flowcell_status'], 'label-default') }}">{{ flowcell['flowcell_status'] }}</span></td>
             <td class="bioinfo-status-row ?"><span class="glyphicon glyphicon-arrow-right"></span></td>
             <td class="bioinfo-status-qc undemultiplexedreads unknown">?</td>

--- a/run_dir/design/deliveries.html
+++ b/run_dir/design/deliveries.html
@@ -119,7 +119,7 @@ Description: Shows a table with all ongoing and incoming bioinformatics projects
               <td class="bioinfo-status-expand"><a href="#bioinfo-fc-{{ project_id }}-{{ flowcell_id }}" class="bioinfo-expand">
                   <span class="glyphicon glyphicon-chevron-right"></span></a></td>
               <td></td>
-              <td class="bioinfo-granularity"><samp><a href="/flowcells/{{ flowcell_id.split('_')[0] }}_{{ flowcell_id.split('_')[-1] }}">{{ flowcell_id }}</a></samp></td>
+              <td class="bioinfo-granularity"><samp><a href="/flowcells/{{ flowcell_id }}">{{ flowcell_id }}</a></samp></td>
               <td><span class="bioinfo-status label {{ status_css.get(flowcell['flowcell_status'], 'label-primary') }}">{{ flowcell['flowcell_status'] }}</span></td>
                 <td class="bi-run-pwf hide-incoming {% if flowcell['checklist']['total'] == flowcell['checklist']['completed'] %} success {% else %} warning {% end %}">
                   <div class="progress">


### PR DESCRIPTION
When a flowcell gets status 'ERROR', it gets resequenced with another run id. 
Both of these runs are displayed on the Delivery page, but as they both have the same short names, they were linked to the same flowcell page, which is wrong.
