### PR TITLE
Project page: QuickFix for Signature NO (for Niclas)

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -73,7 +73,7 @@ Description: Details page for a single project
       <dd><span class="rawdate" id="all_samples_sequenced">-</span>&nbsp; <span id="signature_all_samples_sequenced" class="upperCase label label-default"></span></dd>
 
       <dt>All Raw Data Delivered</dt>
-	    <dd><spanclass="rawdate"  id="all_raw_data_delivered">-</span>&nbsp; <span id="signature_all_raw_data_delivered" class="label label-default"></span></dd>
+	    <dd><span class="rawdate"  id="all_raw_data_delivered">-</span>&nbsp; <span id="signature_all_raw_data_delivered" class="label label-default"></span></dd>
 
       <dt class="bp-dates"><abbr data-toggle="tooltip" title="Best Practice">BP</abbr> Analysis Completed</dt>
 	    <dd class="bp-dates"><span class="rawdate" id="best_practice_analysis_completed">-</span>&nbsp; <span id="signature_best_practice_analysis_completed" class="upperCase label label-default"></span></dd>

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -864,6 +864,13 @@ $('.rawdate').hover(
 );
 
 function make_timescale_bar(tsid, include_orderdates){
+    // special case for Niclas Öhman (NO)
+    // signature NO is replaced to 'No' label
+    var signature_queued = $('#signature_queued span').text();
+    if (signature_queued == 'no') {
+        $('#signature_queued span').remove();
+        $('#signature_queued').text('NO');
+    }
 	// Which elements are we looking at?
   var order_date_ids = [
       	'order_received',


### PR DESCRIPTION
The problem: If someone (for example, Niclas Öhman) has a signature NO, it will be automatically replaced to `No` label, and will look like that (**Project Timeline**): 
https://genomics-status.scilifelab.se/project/P6601

This was done most probably by the function `auto_format` which we have in `base.js`. 
Quick fix, as I wasn't able to find where this function is called for the `signature_queued` label. 
If someone has idea how to fix it properly, I can do that. Otherwise, just removing an extra label.