### PR TITLE
Orders flowcell status chronologically

### DIFF
--- a/run_dir/design/deliveries.html
+++ b/run_dir/design/deliveries.html
@@ -45,11 +45,13 @@ Description: Shows a table with all ongoing and incoming bioinformatics projects
         <div id="visible-classes" class="{{ ' '.join(status_list.keys()) }}"></div>
         <div id="filtered-classes" class=""></div>
         {% for status, number in status_list.items() %}
-        <div class="form-group">
-          <label class="checkbox-inline">
-            <input class="fc-status-checkbox" type="checkbox" value="{{ status }}" checked>{{ status }}
-              <span class="badge badge-small"> {{ number }}</span></label>
-        </div>
+	        {% if number != 0 %}
+	        <div class="form-group">
+	          <label class="checkbox-inline">
+	            <input class="fc-status-checkbox" type="checkbox" value="{{ status }}" checked>{{ status }}
+	              <span class="badge badge-small"> {{ number }}</span></label>
+	        </div>
+	        {% end %}
         {% end %}
       </div>
       <div class="form col-md-4 responsible-filters">

--- a/run_dir/design/deliveries.html
+++ b/run_dir/design/deliveries.html
@@ -10,10 +10,10 @@ Description: Shows a table with all ongoing and incoming bioinformatics projects
 {% block stuff %}
 
 {% set status_css={
-    'Demultiplexing': 'label-default',
-    'Transferring': 'label-default',
     'Sequencing': 'label-default',
+    'Demultiplexing': 'label-default',
     'New': 'label-primary',
+    'Transferring': 'label-default',
     'QC-ongoing': 'label-warning',
     'QC-done': 'label-success',
     'BP-ongoing': 'label-warning',
@@ -44,7 +44,7 @@ Description: Shows a table with all ongoing and incoming bioinformatics projects
         </h4>
         <div id="visible-classes" class="{{ ' '.join(status_list.keys()) }}"></div>
         <div id="filtered-classes" class=""></div>
-        {% for status, number in sorted(status_list.items()) %}
+        {% for status, number in status_list.items() %}
         <div class="form-group">
           <label class="checkbox-inline">
             <input class="fc-status-checkbox" type="checkbox" value="{{ status }}" checked>{{ status }}

--- a/status/deliveries.py
+++ b/status/deliveries.py
@@ -1,4 +1,5 @@
 import json
+from collections import OrderedDict
 
 from status.util import SafeHandler
 
@@ -106,9 +107,15 @@ class DeliveriesPageHandler(SafeHandler):
         number_of_flowcells = 0
         number_of_lanes = 0
         number_of_samples = 0
-        status_list = {}
+        status_list = OrderedDict()
         project_status = {}
         responsible_list = {}
+        #Predefined statuses and order
+        flowcell_statuses=['Sequencing', 'Demultiplexing', 'New', 'QC-ongoing','QC-done','BP-ongoing','BP-done', 'Delivered','ERROR']
+        for status in flowcell_statuses:
+            status_list[status]=0;
+            
+            
         for project_id in ongoing_deliveries:
             if project_id in summary_data and project_id in bioinfo_data:
                 project = summary_data[project_id]
@@ -160,8 +167,6 @@ class DeliveriesPageHandler(SafeHandler):
                     runs_bioinfo[flowcell_id]['checklist'] = flowcell_checklists
 
                     # add flowcell_status to the status_list (needed for filtering)
-                    if flowcell_status not in status_list:
-                        status_list[flowcell_status] = 0
                     status_list[flowcell_status] +=1
 
                     if project_id not in project_status:

--- a/status/deliveries.py
+++ b/status/deliveries.py
@@ -114,8 +114,7 @@ class DeliveriesPageHandler(SafeHandler):
         flowcell_statuses=['Sequencing', 'Demultiplexing', 'New', 'QC-ongoing','QC-done','BP-ongoing','BP-done', 'Delivered','ERROR']
         for status in flowcell_statuses:
             status_list[status]=0;
-            
-            
+                  
         for project_id in ongoing_deliveries:
             if project_id in summary_data and project_id in bioinfo_data:
                 project = summary_data[project_id]
@@ -196,7 +195,6 @@ class DeliveriesPageHandler(SafeHandler):
                     'runs': runs_bioinfo,
                     'latest_running_note': latest_running_note,
                 }
-
 
             else:
                 project_data = {


### PR DESCRIPTION
List is now sorted by step in pipeline. Requires statuses to be predefined though. See no issue with this.
Removes bugged empty status
