### PR TITLE
Read-Only backend for Pricing in genomics status

### DIFF
--- a/status/pricing.py
+++ b/status/pricing.py
@@ -4,30 +4,13 @@ import datetime
 import tornado.web
 from status.util import SafeHandler
 
+
 class PricingBaseHandler(SafeHandler):
-    def fetch_exchange_rates(self, date=None):
-        """Internal method to fetch exchange rates from StatusDB
+    """Base class that other pricing handlers should inherit from.
 
-        Returns the most recent rates prior to date given by parameter `date`
-        If parameter `date` is not supplied, the current timestamp is used.
-
-        returns: dictionary with keys 'USD_in_SEK' and 'EUR_in_SEK'.
-        """
-        if not date:
-            date = datetime.datetime.now()
-
-        str_format_date = date.strftime("%Y-%m-%d")
-        view = self.application.pricing_exchange_rates_db.view(
-                'entire_document/by_date',
-                startkey=str_format_date,
-                descending=True,
-                limit=1
-            )
-
-        result = {}
-        result['USD_in_SEK'] = view.rows[0].value['USD_in_SEK']
-        result['EUR_in_SEK'] = view.rows[0].value['EUR_in_SEK']
-        return result
+    Implements most of the logic of the pricing that other classes should reuse
+    """
+    # _____________________________ HELPER METHODS ____________________________
 
     def _validate_version_param(self, version):
         try:
@@ -48,6 +31,18 @@ class PricingBaseHandler(SafeHandler):
                 )
         return int_key
 
+    def _validate_date_string(self, date):
+            year, month, day = date.split('-')
+
+            try:
+                datetime_date = datetime.datetime(int(year), int(month), int(day))
+            except ValueError:
+                raise tornado.web.HTTPError(
+                    400,
+                    reason='Bad request, date format is not valid (YYYY-MM-DD)'
+                    )
+            return datetime_date
+
     def _validate_single_row_result(self, view, object_type):
         if len(view.rows) == 0:
             raise tornado.web.HTTPError(
@@ -61,64 +56,62 @@ class PricingBaseHandler(SafeHandler):
                            "Expected only 1.".format(object_type)
                 )
 
-    def fetch_individual_component(self, component_id, version=None):
-        """Fetch individual pricing component from StatusDB.
+    # _____________________________ FETCH METHODS _____________________________
 
-        :param component_id: integer id of component to fetch
-        :param version: optional integer specifying version to fetch
-        :return: The row fetched from the database
+    def fetch_components(self, component_id=None, version=None):
+        """Fetch pricing component raw data from StatusDB.
+
+        :param component_id: integer id of component to fetch. If None, all
+                    components are fetched.
+        :param version: optional integer specifying version to fetch,
+                        if None, the latest is fetched
+        :return: The rows fetched from the database
         """
 
-        int_key = self._validate_object_id(component_id, "component")
+        if component_id is not None:
+            int_key = self._validate_object_id(component_id, "component")
 
-        if version is not None:
+        if version is not None:  # Specified version
             int_version = self._validate_version_param(version)
 
-            view = self.application.pricing_components_db.view(
-                        "individual_components/by_id_and_version",
-                        key=[int_key, int_version],
-                        limit=1
-                        )
-        else:
-            view = self.application.pricing_components_db.view(
-                        "individual_components/by_id_and_version",
-                        startkey=[int_key, {}],
-                        endkey=[int_key],
-                        limit=1,
-                        descending=True
-                        )
+            if component_id is None:  # All components
+                view = self.application.pricing_components_db.view(
+                            "entire_document/by_version",
+                            key=int_version,
+                            limit=1,
+                            descending=True
+                            )
+            else:
+                view = self.application.pricing_components_db.view(
+                            "individual_components/by_id_and_version",
+                            key=[int_key, int_version],
+                            limit=1
+                            )
+
+        else:  # No specified version
+            if component_id is None:  # All components
+                view = self.application.pricing_components_db.view(
+                            "entire_document/by_version",
+                            limit=1,
+                            descending=True
+                            )
+            else:
+                view = self.application.pricing_components_db.view(
+                            "individual_components/by_id_and_version",
+                            startkey=[int_key, {}],
+                            endkey=[int_key],
+                            limit=1,
+                            descending=True
+                            )
 
         self._validate_single_row_result(view, "component")
 
-        return view.rows[0]
-
-    def fetch_all_components(self, version=None):
-        """Fetch all pricing component from StatusDB.
-
-        :param version: optional integer specifying version to fetch
-        :return: The row fetched from the database
-        """
-        if version is not None:
-            int_version = self._validate_version_param(version)
-
-            view = self.application.pricing_components_db.view(
-                        "entire_document/by_version",
-                        key=int_version,
-                        limit=1,
-                        descending=True
-                        )
+        if component_id is None:  # All components
+            return view.rows[0].value['components']
         else:
-            view = self.application.pricing_components_db.view(
-                        "entire_document/by_version",
-                        limit=1,
-                        descending=True
-                        )
+            return {component_id: view.rows[0].value}
 
-        self._validate_single_row_result(view, "component")
-
-        return view.rows[0]
-
-    def fetch_individual_product(self, product_id, version=None):
+    def fetch_products_raw(self, product_id, version=None):
         """Fetch individual pricing products from StatusDB.
 
         :param product_id: integer id of product to fetch
@@ -173,9 +166,124 @@ class PricingBaseHandler(SafeHandler):
 
         return view.rows[0]
 
+    def fetch_exchange_rates(self, date=None):
+        """Internal method to fetch exchange rates from StatusDB
 
-class PricingComponentsHandler(PricingBaseHandler):
-    """ Serves data of pricing components
+        :param date: string in format 'YYYY-MM-DD'
+        :return: dictionary with keys 'USD_in_SEK' and 'EUR_in_SEK'.
+
+        Returns the most recent rates prior to date given by parameter `date`
+        If parameter `date` is not supplied, the current timestamp is used.
+        """
+
+        if date is not None:
+            dt = self._validate_date_string(date)
+        else:
+            dt = datetime.datetime.now()
+
+        str_format_date = dt.strftime("%Y-%m-%d")
+        view = self.application.pricing_exchange_rates_db.view(
+                'entire_document/by_date',
+                startkey=str_format_date,
+                descending=True,
+                limit=1
+            )
+
+        result = {}
+        result['USD_in_SEK'] = view.rows[0].value['USD_in_SEK']
+        result['EUR_in_SEK'] = view.rows[0].value['EUR_in_SEK']
+        return result
+
+    # _____________________________ CALCULATION METHODS _______________________
+    def _calculate_component_price(self, component, exch_rates):
+        currency = component['Currency']
+        if currency == 'SEK':
+            sek_list_price = component['List price']
+        else:
+            currency_key = "{}_in_SEK".format(currency)
+            sek_list_price = exch_rates[currency_key] * component['List price']
+
+        sek_price = sek_list_price - sek_list_price * component['Discount']
+
+        sek_price_per_unit = sek_price/float(component['Units'])
+
+        return sek_price, sek_price_per_unit
+
+    def _calculate_product_price(self, product_row, all_components, exch_rates):
+        price = 0
+        for component_id in product_row.value['components']:
+            component = all_components.value['components'][str(component_id)]
+
+            price += self._calculate_component_price(component,
+                                                     exch_rates)[1]
+
+        # Reagents are added to a special field, but are components as well.
+        for reagent in product_row.value['Reagent fee']:
+            component = all_components.value['components'][str(component_id)]
+
+            price += self._calculate_component_price(component,
+                                                     exch_rates)[1]
+
+        return price
+
+    def get_component_prices(self, component_id=None, version=None, date=None):
+        """Calculate prices for individual or all pricing components.
+
+        :param component_id: The id of the component to calculate price for.
+                        If None, all component prices will be calculated.
+        :param version: The version of components to use.
+                        When not specified, the latest version will be used.
+        :param date: The date for which the exchange rate will be fetched.
+                        When not specified, the latest exchange rates will be
+                        used.
+
+        """
+        exch_rates = self.fetch_exchange_rates(date)
+        all_components = self.fetch_components(component_id, version)
+
+        return_d = all_components.copy()
+
+        for component_id, component in all_components.iteritems():
+
+            price, price_per_unit = self._calculate_component_price(component,
+                                                                    exch_rates)
+            return_d[component_id]['price_in_sek'] = price
+            return_d[component_id]['price_per_unit_in_sek'] = price_per_unit
+
+        return return_d
+
+    def get_product_price(self, product_ids, version=None, date=None):
+        """Calculate the price for an individual product
+
+        :param product_id: The id of the product to calculate price of
+        :param version: The version of product and components to use.
+                        When not specified, the latest version will be used.
+        :param date: The date for which the exchange rate will be fetched.
+                        When not specified, the latest exchange rates will be
+                        used.
+
+        In fact, specifying exchange rates date is quite an exotic use case
+        and should be used with care.
+        """
+
+        exch_rates = self.fetch_exchange_rates(date)
+        all_components = self.fetch_all_components(version)
+        for product_id in product_ids:
+            product_row = self.fetch_individual_product(product_id, version)
+
+            self._calculate_product_price(product_row, all_components, exch_rates)
+
+    def get_all_product_prices(self, version=None):
+        # Pick up exchange rates
+        # Pick up component prices
+        # Pick up product prices
+
+        # Calculate the price for each product
+        pass
+
+
+class PricingComponentsDataHandler(PricingBaseHandler):
+    """ Serves price data of pricing components
 
     Loaded through:
         /api/v1/pricing_components
@@ -185,22 +293,24 @@ class PricingComponentsHandler(PricingBaseHandler):
     Use the optional parameter `version` to specify an exact version
     from the database. If omitted, the latest (highest number) version
     will be used.
+    Use the optional parameter `date` to specify an exact date for which the
+    exchange rate will be fetched. When not specified, the latest exchange
+    rates will be used.
     """
 
     def get(self, search_string=None):
         """Returns individual or all components from the database as json"""
-
         version = self.get_argument('version', None)
+        date = self.get_argument('date', None)
 
-        if search_string is not None:
-            row = self.fetch_individual_component(search_string, version)
-        else:
-            row = self.fetch_all_components(version)
+        row = self.get_component_prices(component_id=search_string,
+                                        version=version,
+                                        date=date)
 
         self.write(json.dumps(row))
 
 
-class PricingProductsHandler(PricingBaseHandler):
+class PricingProductsDataHandler(PricingBaseHandler):
     """ Serves data of pricing products
 
     Loaded through:
@@ -226,7 +336,7 @@ class PricingProductsHandler(PricingBaseHandler):
         self.write(json.dumps(row))
 
 
-class PricingDateToVersionHandler(PricingBaseHandler):
+class PricingDateToVersionDataHandler(PricingBaseHandler):
     """Serves a map of when each version of pricing components and
     pricing products was issued.
 
@@ -248,7 +358,7 @@ class PricingDateToVersionHandler(PricingBaseHandler):
         self.write(json.dumps(prod_view.rows))
 
 
-class PricingExchangeRatesHandler(PricingBaseHandler):
+class PricingExchangeRatesDataHandler(PricingBaseHandler):
     """ Serves data of exchange rates
 
     Loaded through:
@@ -266,16 +376,7 @@ class PricingExchangeRatesHandler(PricingBaseHandler):
         date = self.get_argument('date', None)
 
         if date is not None:
-            year, month, day = date.split('-')
-
-            try:
-                dt = datetime.datetime(int(year), int(month), int(day))
-            except ValueError:
-                raise tornado.web.HTTPError(
-                    400,
-                    reason='Bad request, date format is not valid (YYYY-MM-DD)'
-                    )
-            result = self.fetch_exchange_rates(dt)
+            result = self.fetch_exchange_rates(date)
         else:
             result = self.fetch_exchange_rates(None)
 

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -310,6 +310,7 @@ class PricingComponentsDataHandler(PricingBaseHandler):
     Use the optional parameter `date` to specify an exact date for which the
     exchange rate will be fetched. When not specified, the latest exchange
     rates will be used.
+    Any information available for the component(s) will be returned.
     """
 
     def get(self, search_string=None):
@@ -336,6 +337,7 @@ class PricingProductsDataHandler(PricingBaseHandler):
     Use the optional parameter `version` to specify an exact version
     from the database. If omitted, the latest (highest number) version
     will be used.
+    Any information available for the product(s) will be returned.
     """
 
     def get(self, search_string=None):

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -20,7 +20,7 @@ class PricingBaseHandler(SafeHandler):
                 400, reason='Bad request, version is not an integer')
         return int_version
 
-    def _validate_object_id(self, id, object_type):
+    def _validate_object_id(self, id):
         try:
             int_key = int(id)
         except ValueError:

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -1,0 +1,142 @@
+import json
+
+import tornado.web
+from status.util import SafeHandler
+
+
+class PricingComponentsHandler(SafeHandler):
+    """ Serves data of pricing components
+
+    Loaded through:
+        /api/v1/pricing_components
+        /api/v1/pricing_components/([^/]*)$
+
+    where the optional search string is a ref_id of a component.
+    Use the optional parameter `version` to specify an exact version
+    from the database. If ommitted, the latest (highest number) version
+    will be used.
+    """
+
+    def get(self, search_string=None):
+        """Returns individual or all components from the database as json"""
+
+        version = self.get_argument('version', None)
+        if version is not None:
+            try:
+                version = int(version)
+            except ValueError:
+                raise tornado.web.HTTPError(
+                    400, reason='Bad request, version is not an integer')
+
+        if search_string is not None:
+            try:
+                int_key = int(search_string)
+            except ValueError:
+                raise tornado.web.HTTPError(
+                    400, reason='Bad request, component id is not an integer')
+
+            if version is not None:
+                view = self.application.pricing_components_db.view(
+                            "individual_components/by_id_and_version",
+                            key=[int_key, version],
+                            limit=1
+                            )
+            else:
+                view = self.application.pricing_components_db.view(
+                            "individual_components/by_id_and_version",
+                            startkey=[int_key, {}],
+                            endkey=[int_key],
+                            limit=1,
+                            descending=True
+                            )
+
+        # Without search string
+        else:
+            if version is not None:
+                view = self.application.pricing_components_db.view(
+                            "entire_document/by_version",
+                            key=version,
+                            limit=1,
+                            descending=True
+                            )
+            else:
+                view = self.application.pricing_components_db.view(
+                            "entire_document/by_version",
+                            limit=1,
+                            descending=True
+                            )
+
+        if len(view.rows) == 0:
+            raise tornado.web.HTTPError(
+                404, reason='No such component(s) was found'
+            )
+        self.write(json.dumps(view.rows[0]))
+
+
+class PricingProductsHandler(SafeHandler):
+    """ Serves data of pricing products
+
+    Loaded through:
+        /api/v1/pricing_products
+        /api/v1/pricing_products/([^/]*)$
+
+    where the optional search string is an id of a product.
+    Use the optional parameter `version` to specify an exact version
+    from the database. If ommitted, the latest (highest number) version
+    will be used.
+    """
+
+    def get(self, search_string=None):
+        """Returns individual or all products from the database as json"""
+
+        version = self.get_argument('version', None)
+        if version is not None:
+            try:
+                version = int(version)
+            except ValueError:
+                raise tornado.web.HTTPError(
+                    400, reason='Bad request, version is not an integer')
+
+        if search_string is not None:
+            try:
+                int_key = int(search_string)
+            except ValueError:
+                raise tornado.web.HTTPError(
+                    400, reason='Bad request, product id is not an integer')
+
+            if version is not None:
+                view = self.application.pricing_products_db.view(
+                            "individual_products/by_id_and_version",
+                            key=[int_key, version],
+                            limit=1
+                            )
+            else:
+                view = self.application.pricing_products_db.view(
+                            "individual_products/by_id_and_version",
+                            startkey=[int_key, {}],
+                            endkey=[int_key],
+                            limit=1,
+                            descending=True
+                            )
+
+        # Without search string
+        else:
+            if version is not None:
+                view = self.application.pricing_products_db.view(
+                            "entire_document/by_version",
+                            key=version,
+                            limit=1,
+                            descending=True
+                            )
+            else:
+                view = self.application.pricing_products_db.view(
+                            "entire_document/by_version",
+                            limit=1,
+                            descending=True
+                            )
+
+        if len(view.rows) == 0:
+            raise tornado.web.HTTPError(
+                404, reason='No such product(s) was found'
+            )
+        self.write(json.dumps(view.rows[0]))

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -1,10 +1,180 @@
 import json
+import datetime
 
 import tornado.web
 from status.util import SafeHandler
 
+class PricingBaseHandler(SafeHandler):
+    def fetch_exchange_rates(self, date=None):
+        """Internal method to fetch exchange rates from StatusDB
 
-class PricingComponentsHandler(SafeHandler):
+        Returns the most recent rates prior to date given by parameter `date`
+        If parameter `date` is not supplied, the current timestamp is used.
+
+        returns: dictionary with keys 'USD_in_SEK' and 'EUR_in_SEK'.
+        """
+        if not date:
+            date = datetime.datetime.now()
+
+        str_format_date = date.strftime("%Y-%m-%d")
+        view = self.application.pricing_exchange_rates_db.view(
+                'entire_document/by_date',
+                startkey=str_format_date,
+                descending=True,
+                limit=1
+            )
+
+        result = {}
+        result['USD_in_SEK'] = view.rows[0].value['USD_in_SEK']
+        result['EUR_in_SEK'] = view.rows[0].value['EUR_in_SEK']
+        return result
+
+    def _validate_version_param(self, version):
+        try:
+            int_version = int(version)
+        except ValueError:
+            raise tornado.web.HTTPError(
+                400, reason='Bad request, version is not an integer')
+        return int_version
+
+    def _validate_object_id(self, id, object_type):
+        try:
+            int_key = int(id)
+        except ValueError:
+            raise tornado.web.HTTPError(
+                    400,
+                    reason="Bad request, {} id is not "
+                           "an integer".format(object_type)
+                )
+        return int_key
+
+    def _validate_single_row_result(self, view, object_type):
+        if len(view.rows) == 0:
+            raise tornado.web.HTTPError(
+                    404,
+                    reason="No such {}(s) was found".format(object_type)
+                )
+        if len(view.rows) > 1:
+            raise tornado.web.HTTPError(
+                    500,
+                    reason="Internal Server Error: Multiple {} rows returned. "
+                           "Expected only 1.".format(object_type)
+                )
+
+    def fetch_individual_component(self, component_id, version=None):
+        """Fetch individual pricing component from StatusDB.
+
+        :param component_id: integer id of component to fetch
+        :param version: optional integer specifying version to fetch
+        :return: The row fetched from the database
+        """
+
+        int_key = self._validate_object_id(component_id, "component")
+
+        if version is not None:
+            int_version = self._validate_version_param(version)
+
+            view = self.application.pricing_components_db.view(
+                        "individual_components/by_id_and_version",
+                        key=[int_key, int_version],
+                        limit=1
+                        )
+        else:
+            view = self.application.pricing_components_db.view(
+                        "individual_components/by_id_and_version",
+                        startkey=[int_key, {}],
+                        endkey=[int_key],
+                        limit=1,
+                        descending=True
+                        )
+
+        self._validate_single_row_result(view, "component")
+
+        return view.rows[0]
+
+    def fetch_all_components(self, version=None):
+        """Fetch all pricing component from StatusDB.
+
+        :param version: optional integer specifying version to fetch
+        :return: The row fetched from the database
+        """
+        if version is not None:
+            int_version = self._validate_version_param(version)
+
+            view = self.application.pricing_components_db.view(
+                        "entire_document/by_version",
+                        key=int_version,
+                        limit=1,
+                        descending=True
+                        )
+        else:
+            view = self.application.pricing_components_db.view(
+                        "entire_document/by_version",
+                        limit=1,
+                        descending=True
+                        )
+
+        self._validate_single_row_result(view, "component")
+
+        return view.rows[0]
+
+    def fetch_individual_product(self, product_id, version=None):
+        """Fetch individual pricing products from StatusDB.
+
+        :param product_id: integer id of product to fetch
+        :param version: optional integer specifying version to fetch
+        :return: The row fetched from the database
+        """
+        int_key = self._validate_object_id(product_id, "product")
+
+        if version is not None:
+            int_version = self._validate_version_param(version)
+
+            view = self.application.pricing_products_db.view(
+                        "individual_products/by_id_and_version",
+                        key=[int_key, int_version],
+                        limit=1
+                    )
+        else:
+            view = self.application.pricing_products_db.view(
+                        "individual_products/by_id_and_version",
+                        startkey=[int_key, {}],
+                        endkey=[int_key],
+                        limit=1,
+                        descending=True
+                    )
+
+        self._validate_single_row_result(view, "product")
+
+        return view.rows[0]
+
+    def fetch_all_products(self, version=None):
+        """Fetch all pricing product from StatusDB.
+
+        :param version: optional integer specifying version to fetch
+        :return: The row fetched from the database
+        """
+        if version is not None:
+            int_version = self._validate_version_param(version)
+            view = self.application.pricing_products_db.view(
+                        "entire_document/by_version",
+                        key=int_version,
+                        limit=1,
+                        descending=True
+                    )
+        else:
+            view = self.application.pricing_products_db.view(
+                        "entire_document/by_version",
+                        limit=1,
+                        descending=True
+                    )
+
+        self._validate_single_row_result(view, "product")
+
+        return view.rows[0]
+
+
+class PricingComponentsHandler(PricingBaseHandler):
     """ Serves data of pricing components
 
     Loaded through:
@@ -13,7 +183,7 @@ class PricingComponentsHandler(SafeHandler):
 
     where the optional search string is a ref_id of a component.
     Use the optional parameter `version` to specify an exact version
-    from the database. If ommitted, the latest (highest number) version
+    from the database. If omitted, the latest (highest number) version
     will be used.
     """
 
@@ -21,59 +191,16 @@ class PricingComponentsHandler(SafeHandler):
         """Returns individual or all components from the database as json"""
 
         version = self.get_argument('version', None)
-        if version is not None:
-            try:
-                version = int(version)
-            except ValueError:
-                raise tornado.web.HTTPError(
-                    400, reason='Bad request, version is not an integer')
 
         if search_string is not None:
-            try:
-                int_key = int(search_string)
-            except ValueError:
-                raise tornado.web.HTTPError(
-                    400, reason='Bad request, component id is not an integer')
-
-            if version is not None:
-                view = self.application.pricing_components_db.view(
-                            "individual_components/by_id_and_version",
-                            key=[int_key, version],
-                            limit=1
-                            )
-            else:
-                view = self.application.pricing_components_db.view(
-                            "individual_components/by_id_and_version",
-                            startkey=[int_key, {}],
-                            endkey=[int_key],
-                            limit=1,
-                            descending=True
-                            )
-
-        # Without search string
+            row = self.fetch_individual_component(search_string, version)
         else:
-            if version is not None:
-                view = self.application.pricing_components_db.view(
-                            "entire_document/by_version",
-                            key=version,
-                            limit=1,
-                            descending=True
-                            )
-            else:
-                view = self.application.pricing_components_db.view(
-                            "entire_document/by_version",
-                            limit=1,
-                            descending=True
-                            )
+            row = self.fetch_all_components(version)
 
-        if len(view.rows) == 0:
-            raise tornado.web.HTTPError(
-                404, reason='No such component(s) was found'
-            )
-        self.write(json.dumps(view.rows[0]))
+        self.write(json.dumps(row))
 
 
-class PricingProductsHandler(SafeHandler):
+class PricingProductsHandler(PricingBaseHandler):
     """ Serves data of pricing products
 
     Loaded through:
@@ -82,7 +209,7 @@ class PricingProductsHandler(SafeHandler):
 
     where the optional search string is an id of a product.
     Use the optional parameter `version` to specify an exact version
-    from the database. If ommitted, the latest (highest number) version
+    from the database. If omitted, the latest (highest number) version
     will be used.
     """
 
@@ -90,53 +217,66 @@ class PricingProductsHandler(SafeHandler):
         """Returns individual or all products from the database as json"""
 
         version = self.get_argument('version', None)
-        if version is not None:
-            try:
-                version = int(version)
-            except ValueError:
-                raise tornado.web.HTTPError(
-                    400, reason='Bad request, version is not an integer')
 
         if search_string is not None:
+            row = self.fetch_individual_product(search_string, version)
+        else:
+            row = self.fetch_all_products(version)
+
+        self.write(json.dumps(row))
+
+
+class PricingDateToVersionHandler(PricingBaseHandler):
+    """Serves a map of when each version of pricing components and
+    pricing products was issued.
+
+    Loaded through:
+        /api/v1/pricing_date_to_version
+
+    Use this to be able to look back in history of the components and
+    products database at certain dates.
+    """
+
+    def get(self):
+        # The versions of products and components should match perfectly,
+        # so we only need to fetch from one database.
+        prod_view = self.application.pricing_products_db.view(
+                        "version_info/by_date",
+                        descending=False
+                        )
+
+        self.write(json.dumps(prod_view.rows))
+
+
+class PricingExchangeRatesHandler(PricingBaseHandler):
+    """ Serves data of exchange rates
+
+    Loaded through:
+        /api/v1/pricing_exchange_rates
+        /api/v1/pricing_exchange_rates?date=YYYY-MM-DD
+
+    Use the optional parameter `date` if anything else than the latest
+    exchange rates are needed. The format should be as indicated above.
+    The most recent exchange rates prior to the `date` will be served.
+
+    If `date` is omitted, the most recent exchange rates will be served.
+    """
+
+    def get(self):
+        date = self.get_argument('date', None)
+
+        if date is not None:
+            year, month, day = date.split('-')
+
             try:
-                int_key = int(search_string)
+                dt = datetime.datetime(int(year), int(month), int(day))
             except ValueError:
                 raise tornado.web.HTTPError(
-                    400, reason='Bad request, product id is not an integer')
-
-            if version is not None:
-                view = self.application.pricing_products_db.view(
-                            "individual_products/by_id_and_version",
-                            key=[int_key, version],
-                            limit=1
-                            )
-            else:
-                view = self.application.pricing_products_db.view(
-                            "individual_products/by_id_and_version",
-                            startkey=[int_key, {}],
-                            endkey=[int_key],
-                            limit=1,
-                            descending=True
-                            )
-
-        # Without search string
+                    400,
+                    reason='Bad request, date format is not valid (YYYY-MM-DD)'
+                    )
+            result = self.fetch_exchange_rates(dt)
         else:
-            if version is not None:
-                view = self.application.pricing_products_db.view(
-                            "entire_document/by_version",
-                            key=version,
-                            limit=1,
-                            descending=True
-                            )
-            else:
-                view = self.application.pricing_products_db.view(
-                            "entire_document/by_version",
-                            limit=1,
-                            descending=True
-                            )
+            result = self.fetch_exchange_rates(None)
 
-        if len(view.rows) == 0:
-            raise tornado.web.HTTPError(
-                404, reason='No such product(s) was found'
-            )
-        self.write(json.dumps(view.rows[0]))
+        self.write(json.dumps(result))

--- a/status_app.py
+++ b/status_app.py
@@ -28,8 +28,8 @@ from status.flowcells import FlowcellDemultiplexHandler, FlowcellLinksDataHandle
     FlowcellsHandler, FlowcellsInfoDataHandler, OldFlowcellsInfoDataHandler, ReadsTotalHandler
 from status.instruments import InstrumentLogsHandler, DataInstrumentLogsHandler, InstrumentNamesHandler
 from status.multiqc_report import MultiQCReportHandler
-from status.pricing import PricingComponentsHandler, PricingProductsHandler, \
-    PricingDateToVersionHandler, PricingExchangeRatesHandler
+from status.pricing import PricingComponentsDataHandler, PricingProductsDataHandler, \
+    PricingDateToVersionDataHandler, PricingExchangeRatesDataHandler
 from status.production import DeliveredMonthlyDataHandler, DeliveredMonthlyPlotHandler, DeliveredQuarterlyDataHandler, \
     DeliveredQuarterlyPlotHandler, ProducedMonthlyDataHandler, ProducedMonthlyPlotHandler, ProducedQuarterlyDataHandler, \
     ProducedQuarterlyPlotHandler, ProductionCronjobsHandler
@@ -131,12 +131,12 @@ class Application(tornado.web.Application):
             ("/api/v1/plot/samples_per_lane.png",
                 SamplesPerLanePlotHandler),
             ("/api/v1/samples_per_lane", SamplesPerLaneDataHandler),
-            ("/api/v1/pricing_date_to_version", PricingDateToVersionHandler),
-            ("/api/v1/pricing_components", PricingComponentsHandler),
-            ("/api/v1/pricing_components/([^/]*)$", PricingComponentsHandler),
-            ("/api/v1/pricing_exchange_rates", PricingExchangeRatesHandler),
-            ("/api/v1/pricing_products", PricingProductsHandler),
-            ("/api/v1/pricing_products/([^/]*)$", PricingProductsHandler),
+            ("/api/v1/pricing_date_to_version", PricingDateToVersionDataHandler),
+            ("/api/v1/pricing_components", PricingComponentsDataHandler),
+            ("/api/v1/pricing_components/([^/]*)$", PricingComponentsDataHandler),
+            ("/api/v1/pricing_exchange_rates", PricingExchangeRatesDataHandler),
+            ("/api/v1/pricing_products", PricingProductsDataHandler),
+            ("/api/v1/pricing_products/([^/]*)$", PricingProductsDataHandler),
             ("/api/v1/produced_monthly", ProducedMonthlyDataHandler),
             ("/api/v1/produced_monthly.png", ProducedMonthlyPlotHandler),
             ("/api/v1/produced_quarterly", ProducedQuarterlyDataHandler),

--- a/status_app.py
+++ b/status_app.py
@@ -28,6 +28,7 @@ from status.flowcells import FlowcellDemultiplexHandler, FlowcellLinksDataHandle
     FlowcellsHandler, FlowcellsInfoDataHandler, OldFlowcellsInfoDataHandler, ReadsTotalHandler
 from status.instruments import InstrumentLogsHandler, DataInstrumentLogsHandler, InstrumentNamesHandler
 from status.multiqc_report import MultiQCReportHandler
+from status.pricing import PricingComponentsHandler, PricingProductsHandler
 from status.production import DeliveredMonthlyDataHandler, DeliveredMonthlyPlotHandler, DeliveredQuarterlyDataHandler, \
     DeliveredQuarterlyPlotHandler, ProducedMonthlyDataHandler, ProducedMonthlyPlotHandler, ProducedQuarterlyDataHandler, \
     ProducedQuarterlyPlotHandler, ProductionCronjobsHandler
@@ -129,6 +130,10 @@ class Application(tornado.web.Application):
             ("/api/v1/plot/samples_per_lane.png",
                 SamplesPerLanePlotHandler),
             ("/api/v1/samples_per_lane", SamplesPerLaneDataHandler),
+            ("/api/v1/pricing_components", PricingComponentsHandler),
+            ("/api/v1/pricing_components/([^/]*)$", PricingComponentsHandler),
+            ("/api/v1/pricing_products", PricingProductsHandler),
+            ("/api/v1/pricing_products/([^/]*)$", PricingProductsHandler),
             ("/api/v1/produced_monthly", ProducedMonthlyDataHandler),
             ("/api/v1/produced_monthly.png", ProducedMonthlyPlotHandler),
             ("/api/v1/produced_quarterly", ProducedQuarterlyDataHandler),
@@ -219,6 +224,8 @@ class Application(tornado.web.Application):
             self.gs_users_db = couch["gs_users"]
             self.instruments_db= couch["instruments"]
             self.instrument_logs_db = couch["instrument_logs"]
+            self.pricing_components_db = couch["pricing_components"]
+            self.pricing_products_db = couch["pricing_products"]
             self.projects_db = couch["projects"]
             self.samples_db = couch["samples"]
             self.server_status_db = couch['server_status']

--- a/status_app.py
+++ b/status_app.py
@@ -28,7 +28,8 @@ from status.flowcells import FlowcellDemultiplexHandler, FlowcellLinksDataHandle
     FlowcellsHandler, FlowcellsInfoDataHandler, OldFlowcellsInfoDataHandler, ReadsTotalHandler
 from status.instruments import InstrumentLogsHandler, DataInstrumentLogsHandler, InstrumentNamesHandler
 from status.multiqc_report import MultiQCReportHandler
-from status.pricing import PricingComponentsHandler, PricingProductsHandler
+from status.pricing import PricingComponentsHandler, PricingProductsHandler, \
+    PricingDateToVersionHandler, PricingExchangeRatesHandler
 from status.production import DeliveredMonthlyDataHandler, DeliveredMonthlyPlotHandler, DeliveredQuarterlyDataHandler, \
     DeliveredQuarterlyPlotHandler, ProducedMonthlyDataHandler, ProducedMonthlyPlotHandler, ProducedQuarterlyDataHandler, \
     ProducedQuarterlyPlotHandler, ProductionCronjobsHandler
@@ -130,8 +131,10 @@ class Application(tornado.web.Application):
             ("/api/v1/plot/samples_per_lane.png",
                 SamplesPerLanePlotHandler),
             ("/api/v1/samples_per_lane", SamplesPerLaneDataHandler),
+            ("/api/v1/pricing_date_to_version", PricingDateToVersionHandler),
             ("/api/v1/pricing_components", PricingComponentsHandler),
             ("/api/v1/pricing_components/([^/]*)$", PricingComponentsHandler),
+            ("/api/v1/pricing_exchange_rates", PricingExchangeRatesHandler),
             ("/api/v1/pricing_products", PricingProductsHandler),
             ("/api/v1/pricing_products/([^/]*)$", PricingProductsHandler),
             ("/api/v1/produced_monthly", ProducedMonthlyDataHandler),
@@ -225,6 +228,7 @@ class Application(tornado.web.Application):
             self.instruments_db= couch["instruments"]
             self.instrument_logs_db = couch["instrument_logs"]
             self.pricing_components_db = couch["pricing_components"]
+            self.pricing_exchange_rates_db = couch["pricing_exchange_rates"]
             self.pricing_products_db = couch["pricing_products"]
             self.projects_db = couch["projects"]
             self.samples_db = couch["samples"]


### PR DESCRIPTION
This together with https://github.com/SciLifeLab/standalone_scripts/pull/53 can reproduce the numbers for prices available in the excel sheet currently used (1378 Cost Calculator). It is read-only at this stage but the plan is to extend it with write functionality next.

The basic logic is that an order consists of different products which in turn consists of a number of components, so:
ORDERS -> PRODUCTS -> COMPONENTS

However, the order level is not yet implemented.

These are the URL:s implemented (GET):
```
            /api/v1/pricing_date_to_version
            /api/v1/pricing_components
            /api/v1/pricing_components/<ID>
            /api/v1/pricing_exchange_rates
            /api/v1/pricing_products
            /api/v1/pricing_products/<ID>
```