### PR TITLE
Flowcells subsection load

### DIFF
--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -11,7 +11,7 @@ Description: Shows a table with all flow cells.
 
 <div class="container-fluid" id="flowcell_list">
   <div id="fc_table_div">
-      <h1><span id="page_title">Flowcells {{all}}</span>
+      <h1><span id="page_title">Flowcells</span>
           {% if all %}
             <small>Showing all flowcells</small>
             <a class="btn btn-default" href="/flowcells">Filter to only last 6 months</a>

--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -14,7 +14,7 @@ Description: Shows a table with all flow cells.
       <h1><span id="page_title">Flowcells</span>
           {% if all %}
             <small>Showing all flowcells</small>
-            <a class="btn btn-default" href="/flowcells">Filter to only last 6 months</a>
+            <a class="btn btn-default" href="/flowcells">Show last 6 months only</a>
           {% else %}
             <small>Showing flowcells from the last 6 months.</small>
             <a class="btn btn-default" href="/flowcells?all=True">Show all</a>

--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -11,7 +11,15 @@ Description: Shows a table with all flow cells.
 
 <div class="container-fluid" id="flowcell_list">
   <div id="fc_table_div">
-      <h1><span id="page_title">Flowcells</span> </h1>
+      <h1><span id="page_title">Flowcells {{all}}</span>
+          {% if all %}
+            <small>Showing all flowcells</small>
+            <a class="btn btn-default" href="/flowcells">Filter to only last 6 months</a>
+          {% else %}
+            <small>Showing flowcells from the last 6 months.</small>
+            <a class="btn btn-default" href="/flowcells?all=True">Show all</a>
+          {% end %}
+      </h1>
       <table class="table table-striped table-bordered sortable" id="fc_table">
         <thead>
           <tr class="sticky">

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -4,6 +4,7 @@
 import tornado.web
 import json
 import datetime
+from dateutil.relativedelta import relativedelta
 
 from genologics.entities import Container
 from genologics import lims
@@ -31,17 +32,26 @@ def formatDate(date):
 
 class FlowcellsHandler(SafeHandler):
     """ Serves a page which lists all flowcells with some brief info.
+    By default shows only flowcells form the last 6 months, use the parameter
+    'all' to show all flowcells.
     """
-    def list_flowcells(self):
+    def list_flowcells(self, all=False):
         flowcells = OrderedDict()
         temp_flowcells={}
-        fc_view = self.application.flowcells_db.view("info/summary",
-                                                     descending=True)
-        for row in fc_view:
-            temp_flowcells[row.key] = row.value
+        if all: # fc_view are from 2016 and older
+            fc_view = self.application.flowcells_db.view("info/summary",
+                                                        descending=True)
+            for row in fc_view:
+                temp_flowcells[row.key] = row.value
 
-        xfc_view = self.application.x_flowcells_db.view("info/summary",
-                                                     descending=True)
+        if all:
+            xfc_view = self.application.x_flowcells_db.view("info/summary",
+                                                            descending=True)
+        else:
+            half_a_year_ago = (datetime.datetime.now() - relativedelta(months=6)).strftime("%y%m%d")
+            xfc_view = self.application.x_flowcells_db.view("info/summary",
+                                                            descending=True,
+                                                            endkey=half_a_year_ago)
         for row in xfc_view:
             try:
                 row.value['startdate'] = datetime.datetime.strptime(row.value['startdate'], "%y%m%d").strftime("%Y-%m-%d")
@@ -57,9 +67,11 @@ class FlowcellsHandler(SafeHandler):
         return OrderedDict(sorted(temp_flowcells.items(), reverse=True))
 
     def get(self):
+        # Default is to NOT show all flowcells
+        all=self.get_argument("all", False)
         t = self.application.loader.load("flowcells.html")
-        fcs=self.list_flowcells()
-        self.write(t.generate(gs_globals=self.application.gs_globals, thresholds=thresholds, user=self.get_current_user_name(), flowcells=fcs, form_date=formatDate))
+        fcs=self.list_flowcells(all=all)
+        self.write(t.generate(gs_globals=self.application.gs_globals, thresholds=thresholds, user=self.get_current_user_name(), flowcells=fcs, form_date=formatDate, all=all))
 
 
 class FlowcellHandler(SafeHandler):

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -37,17 +37,17 @@ class FlowcellsHandler(SafeHandler):
     """
     def list_flowcells(self, all=False):
         flowcells = OrderedDict()
-        temp_flowcells={}
-        if all: # fc_view are from 2016 and older
+        temp_flowcells = {}
+        if all:
             fc_view = self.application.flowcells_db.view("info/summary",
                                                         descending=True)
             for row in fc_view:
                 temp_flowcells[row.key] = row.value
 
-        if all:
             xfc_view = self.application.x_flowcells_db.view("info/summary",
                                                             descending=True)
         else:
+            # fc_view are from 2016 and older so only include xfc_view here
             half_a_year_ago = (datetime.datetime.now() - relativedelta(months=6)).strftime("%y%m%d")
             xfc_view = self.application.x_flowcells_db.view("info/summary",
                                                             descending=True,


### PR DESCRIPTION
This will speed up page load for flowcells list, and I don't think we look at flowcells older than 6 months more than occasionally. Will be easy to get all flowcells when needed in that case.

This PR might need some styling/css assistance... :)

Default view:
![screen shot 2019-02-12 at 13 21 41](https://user-images.githubusercontent.com/1250075/52635197-8b301880-2ec9-11e9-83a4-5d69b1abc7b4.png)


The view when showing all flowcells:
![screen shot 2019-02-12 at 13 22 13](https://user-images.githubusercontent.com/1250075/52635198-8b301880-2ec9-11e9-971d-97fa246fbd09.png)