### PR TITLE
Uncheck HiSeq checkboxes and divide instruments

### DIFF
--- a/run_dir/design/flowcell_trend_plot.html
+++ b/run_dir/design/flowcell_trend_plot.html
@@ -84,8 +84,8 @@ Description: Plots the yield of recent flowcells.
                 See :
                 <input id="filter_hiseq" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="D" /> HiSeq
                 <input id="filter_hiseqX" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="E" /> HiSeq X
-                <input id="filter_miseq" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="M" /> MiSeq
-                <input id="filter_novaseq" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="A" /> NovaSeq
+                <input id="filter_miseq" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="M" checked /> MiSeq
+                <input id="filter_novaseq" class="filter_inst_type" type="checkbox" name="inst_type_filter" value="A" checked /> NovaSeq
             </form>
 
         </div>

--- a/run_dir/static/js/fc_trend_plot.js
+++ b/run_dir/static/js/fc_trend_plot.js
@@ -337,9 +337,9 @@ function init_page_js(){
         refresh_plot();
         
     });
-    $(".filter_inst_type").each(function(e){
-        $(this).prop('checked', true);
-    });
+    //    $(".filter_inst_type").each(function(e){
+    //	$(this).prop('checked', true);
+    //    });
     $(".filter_inst_type").change(function(e){
         e.stopImmediatePropagation()
         refresh_plot();

--- a/run_dir/static/js/fc_trend_plot.js
+++ b/run_dir/static/js/fc_trend_plot.js
@@ -384,7 +384,7 @@ function update_instrument_list(){
 }
 function update_instrument_filters(){
     var html='<ul class="list-inline">Filter out instruments ';
-    var html_hiseq='<ul class="list-inline">Filter out old intruments ';
+    var html_hiseq='<ul class="list-inline">Filter out old instruments ';
     var my_inst_id='';
     var my_inst_name='';
     var old_inst=['D00415', 'ST-E00269', 'ST-E00198', 'ST-E00201', 'D00410', 'ST-E00214', 'ST-E00266'];

--- a/run_dir/static/js/fc_trend_plot.js
+++ b/run_dir/static/js/fc_trend_plot.js
@@ -383,28 +383,49 @@ function update_instrument_list(){
     }
 }
 function update_instrument_filters(){
-    var html='<ul class="list-inline">Filter out ';
+    var html='<ul class="list-inline">Filter out instruments ';
+    var html_hiseq='<ul class="list-inline">Filter out old intruments ';
     var my_inst_id='';
     var my_inst_name='';
+    var old_inst=['D00415', 'ST-E00269', 'ST-E00198', 'ST-E00201', 'D00410', 'ST-E00214', 'ST-E00266'];
     $.getJSON("/api/v1/instrument_names", function(data){
         for (i in window.current_instrument_list){
             my_inst_id=window.current_instrument_list[i];
-            html+='<li class="filter_insts" id="inst_filter_'+my_inst_id+'"style="cursor:pointer;border-left: 5px solid '+color_by_instrument(my_inst_id)+';">';
-            for (d in data){
-            my_inst_name='';
-                if(my_inst_id.indexOf(data[d].key)!= -1){
-                    my_inst_name=data[d].value;
-                    break;
-                }
-            }
-            if (my_inst_name==''){
-                my_inst_name=my_inst_id;
-            }
-            html+=my_inst_name + "</li>";
+      	    if (old_inst.indexOf(my_inst_id) == -1){
+		html+='<li class="filter_insts" id="inst_filter_'+my_inst_id+'"style="cursor:pointer;border-left: 5px solid '+color_by_instrument(my_inst_id)+';">';
+		for (d in data){
+		    my_inst_name='';
+		    if(my_inst_id.indexOf(data[d].key)!= -1){
+			my_inst_name=data[d].value;
+			break;
+		    }
+		}
+		if (my_inst_name==''){
+		    my_inst_name=my_inst_id;
+		}
+		html+=my_inst_name + "</li>";
 
-            html+=" ";
-        }
+		html+=" ";
+	    } else {
+		html_hiseq+='<li class="filter_insts" id="inst_filter_'+my_inst_id+'"style="cursor:pointer;border-left: 5px solid '+color_by_instrument(my_inst_id)+';">';
+                for (d in data){
+                    my_inst_name='';
+                    if(my_inst_id.indexOf(data[d].key)!= -1){
+                        my_inst_name=data[d].value;
+                        break;
+                    }
+                }
+                if (my_inst_name==''){
+                    my_inst_name=my_inst_id;
+                }
+                html_hiseq+=my_inst_name + "</li>";
+
+                html_hiseq+=" ";
+            }
+	}
         html+="</ul>";
+        html_hiseq+="</ul>";
+	html+=html_hiseq
         $("#inst_filter_div").html(html);
         
         $(".filter_insts").click(function(e){

--- a/run_dir/static/js/fc_trend_plot.js
+++ b/run_dir/static/js/fc_trend_plot.js
@@ -337,9 +337,6 @@ function init_page_js(){
         refresh_plot();
         
     });
-    //    $(".filter_inst_type").each(function(e){
-    //	$(this).prop('checked', true);
-    //    });
     $(".filter_inst_type").change(function(e){
         e.stopImmediatePropagation()
         refresh_plot();


### PR DESCRIPTION
- Making the HiSeq(x) checkboxes unchecked by default
- Putting the HiSeq(x) instruments from the instrument list into a separate list