### PR TITLE
Switched the genomics-status links for the dashboards

### DIFF
--- a/run_dir/design/index.html
+++ b/run_dir/design/index.html
@@ -30,14 +30,14 @@
 	</div>
 	<div class="col-lg-2 col-sm-4 col-xs-6">
 		<div class="well">
-			  <h3><a href="http://tools.scilifelab.se/dbi/"><i class="glyphicon glyphicon-dashboard"></i></a></h3>
-			<p><a class="btn btn-primary"  href="http://tools.scilifelab.se/dbi/">Internal Dashboard</a></p>
+			  <h3><a href="https://ngi-dashboards.scilifelab.se/dbi/"><i class="glyphicon glyphicon-dashboard"></i></a></h3>
+			<p><a class="btn btn-primary"  href="https://ngi-dashboards.scilifelab.se/dbi/">Internal Dashboard</a></p>
 		</div>
 	</div>
 	<div class="col-lg-2 col-sm-4 col-xs-6">
 		<div class="well">
-			  <h3><a href="http://tools.scilifelab.se/dbe/"><i class="glyphicon glyphicon-globe"></i></a></h3>
-			<p><a class="btn btn-primary"  href="http://tools.scilifelab.se/dbe/">External Dashboard</a></p>
+			  <h3><a href="https://ngi-dashboards.scilifelab.se/dbe/"><i class="glyphicon glyphicon-globe"></i></a></h3>
+			<p><a class="btn btn-primary"  href="https://ngi-dashboards.scilifelab.se/dbe/">External Dashboard</a></p>
 		</div>
 	</div>
 </div>


### PR DESCRIPTION
As as step when getting rid of the old server: Switch the URL:s for the dashboard to point to the new server.