### PR TITLE
Added latest workset note, statuses and "copy table"-button to the worksets table

### DIFF
--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -73,15 +73,15 @@ Description: Shows a table with all worksets.
                          {% raw '</samp><hr style="margin:0;"><samp>'.join(ws_data[onews].get(onekey[1])) %}
                          </samp></td>
                      {% elif onekey[1] in ['passed', 'failed', 'unknown', 'total'] %}
-                         <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td>
-                     {% elif onekey[1] == 'workset_notes'%}
-                         <td class="latest_workset_note" class="text-center">
-                         {% if ws_data[onews].get('workset_notes') %}
-                              {% set workset_notes = ws_data[onews].get('workset_notes') %}
-                              {% set latest_workset_note_key = max(k for k, v in workset_notes.items() if v != '') %}
+                         <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td> 
+                     {% elif onekey[1] == 'Workset Notes'%}
+                         <td class="latest_workset_note" class="text-center" style="min-width:250px">
+                         {% if ws_data[onews].get('Workset Notes') %}
+                              {% set workset_notes = ws_data[onews].get('Workset Notes') %}
+                              {% set latest_workset_note_key = list(workset_notes.keys())[0] %}
                               <div class="panel panel-default running-note-panel">
                               <div class='panel-heading'>
-                              <a href='mailto:{{ workset_notes[latest_workset_note_key]["email"].encode("ascii","ignore")}}'>{{ workset_notes[latest_workset_note_key]["user"].encode("ascii","ignore")}}</a>  -  {{form_date(latest_workset_note_key)}}
+                              <a href='mailto:{{ workset_notes[latest_workset_note_key]["email"].encode("ascii","ignore")}}'>{{ workset_notes[latest_workset_note_key]["user"].encode("ascii","ignore")}}</a>  -  {{ datetime.datetime.strptime(latest_workset_note_key, "%Y-%m-%d %H:%M:%S.%f").strftime("%a %b %d %Y, %I:%M:%S %p") }}
                               </div>
                               <div class='panel-body' style='white-space: pre-line'>
                               {{workset_notes[latest_workset_note_key]['note']}}
@@ -99,7 +99,13 @@ Description: Shows a table with all worksets.
           </table>
         </div>
       </div>
-
+      <script type="text/javascript">
+      $( document ).ready(function() {
+       $(".running-note-panel > .panel-body").each(function(i){
+         $(this).html(make_markdown($(this).text()));
+       });
+      });
+      </script>
       <div class="tab-pane fade" id="tab_pending_samples_to_worksets">
         <h2 class="worksets_page_heading"> <small>All samples that are available to be added to a workset in LIMS.</small></h2>
         <div id="samples-to-workset-list">

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -55,10 +55,10 @@ Description: Shows a table with all worksets.
                          <td>
                          {% for onepj in ws_data.get(onews).get(onekey[1]) %}
                             {% if ws_data.get(onews).get(onekey[1]).get(onepj).get('status') == 'Open' %}
-                                <a href="/project/{{ onepj }}" class="open_ws_link" data-toggle="tooltip" title="Status: Open"><i class="glyphicon glyphicon-folder-open">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
+                                <a href="/project/{{ onepj }}" class="text-success" data-toggle="tooltip" title="Status: Open"><i class="glyphicon glyphicon-folder-open">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
                             {% end %}
                             {% if ws_data.get(onews).get(onekey[1]).get(onepj).get('status') == 'Closed' %}
-                                <a href="/project/{{ onepj }}" class="closed_ws_link" data-toggle="tooltip" title="Status: Closed"><i class="glyphicon glyphicon-folder-close">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
+                                <a href="/project/{{ onepj }}" class="text-warning" data-toggle="tooltip" title="Status: Closed"><i class="glyphicon glyphicon-folder-close">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
                             {% end %}
                             &nbsp;({{ ws_data.get(onews).get(onekey[1]).get(onepj).get('samples_nb') }})<br>
                             {% end %}

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -23,7 +23,10 @@ Description: Shows a table with all worksets.
         {% else %}
           <h2 id="{{ worksets }}" class="worksets_page_heading"> <small>Worksets from the last 6 months. </small><a class="btn btn-default" href="/worksets?all=True">Show all</a></h2>
         {% end %}
-        <div id="workset-list">
+        <div class="form-group">	
+	      <button type="button" id="ws_copy_table" class="btn btn-sm btn-default" data-clipboard-target="#workset_table"><span class="glyphicon glyphicon-copy"></span> Copy table</button>
+        <div id="workset-list">	
+        &nbsp;
           <table class="table table-striped table-bordered sortable" id="workset_table">
             <thead id="workset_table_head">
                 <tr class="sticky">
@@ -131,4 +134,5 @@ Description: Shows a table with all worksets.
 <!-- #page_content -->
 <script src="/static/js/jquery.dataTables.min.js? }}"></script>
 <script src="/static/js/worksets.js?v={{ gs_globals['git_commit'] }}" id="worksets-js" data-worksets="{{worksets}}"></script>
+<script src="/static/js/clipboard.min.js"></script>
 {% end %}

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -99,13 +99,6 @@ Description: Shows a table with all worksets.
           </table>
         </div>
       </div>
-      <script type="text/javascript">
-      $( document ).ready(function() {
-       $(".running-note-panel > .panel-body").each(function(i){
-         $(this).html(make_markdown($(this).text()));
-       });
-      });
-      </script>
       <div class="tab-pane fade" id="tab_pending_samples_to_worksets">
         <h2 class="worksets_page_heading"> <small>All samples that are available to be added to a workset in LIMS.</small></h2>
         <div id="samples-to-workset-list">

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -74,12 +74,27 @@ Description: Shows a table with all worksets.
                          </samp></td>
                      {% elif onekey[1] in ['passed', 'failed', 'unknown', 'total'] %}
                          <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td>
+                     {% elif onekey[1] == 'workset_notes'%}
+                         <td class="latest_workset_note" class="text-center">
+                         {% if ws_data[onews].get('workset_notes') %}
+                              {% set workset_notes = ws_data[onews].get('workset_notes') %}
+                              {% set latest_workset_note_key = max(k for k, v in workset_notes.items() if v != '') %}
+                              <div class="panel panel-default running-note-panel">
+                              <div class='panel-heading'>
+                              <a href='mailto:{{ workset_notes[latest_workset_note_key]["email"].encode("ascii","ignore")}}'>{{ workset_notes[latest_workset_note_key]["user"].encode("ascii","ignore")}}</a>  -  {{form_date(latest_workset_note_key)}}
+                              </div>
+                              <div class='panel-body' style='white-space: pre-line'>
+                              {{workset_notes[latest_workset_note_key]['note']}}
+                              </div>
+                              </div>
+                         {% end %}
+                        </td>
                      {% else %}
                         <td>{{ ws_data[onews].get(onekey[1]) }}</td>
                      {% end %}
                  {% end %}
-                 </tr>
                  {% end %}
+                </tr>
             </tbody>
           </table>
         </div>
@@ -114,8 +129,6 @@ Description: Shows a table with all worksets.
   </div>
 </div>
 <!-- #page_content -->
-
 <script src="/static/js/jquery.dataTables.min.js? }}"></script>
 <script src="/static/js/worksets.js?v={{ gs_globals['git_commit'] }}" id="worksets-js" data-worksets="{{worksets}}"></script>
-<script src="/static/js/jquery-ui.min.js"></script>
 {% end %}

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -49,18 +49,19 @@ Description: Shows a table with all worksets.
                          </td>
                      {% elif onekey[1] == 'workset_name'%}
                          <td>
-                         <a href="/workset/{{ onews }}">{{ onews }}</a>
+                         <a href="/workset/{{ onews }}" style="color:#000000;">{{ onews }}</a>
                          </td>
                      {% elif onekey[1] == 'projects'%}
                          <td>
                          {% for onepj in ws_data.get(onews).get(onekey[1]) %}
-                         <abbr title="{{ ws_data.get(onews).get(onekey[1]).get(onepj).get('project_name')}}">
-                             <a href="/project/{{ onepj }}">{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a></abbr>
-                         {% if  ws_data.get(onews).get(onekey[1]).get(onepj).get('status') == 'Closed' %}
-                         <abbr title="Project closed">&nbsp;<span class="glyphicon glyphicon-ok-sign"></span></abbr>
-                         {% end %}
-                         &nbsp;({{ ws_data.get(onews).get(onekey[1]).get(onepj).get('samples_nb') }})<br>
-                         {% end %}
+                            {% if ws_data.get(onews).get(onekey[1]).get(onepj).get('status') == 'Open' %}
+                                <a href="/project/{{ onepj }}" class="open_ws_link" data-toggle="tooltip" title="Status: Open"><i class="glyphicon glyphicon-folder-open">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
+                            {% end %}
+                            {% if ws_data.get(onews).get(onekey[1]).get(onepj).get('status') == 'Closed' %}
+                                <a href="/project/{{ onepj }}" class="closed_ws_link" data-toggle="tooltip" title="Status: Closed"><i class="glyphicon glyphicon-folder-close">&nbsp;</i>{{ ", ".join([ws_data.get(onews, {}).get(onekey[1], {}).get(onepj, {}).get('project_name', 'NA'), onepj]) }}</a>
+                            {% end %}
+                            &nbsp;({{ ws_data.get(onews).get(onekey[1]).get(onepj).get('samples_nb') }})<br>
+                            {% end %}
                          </td>
                      {% elif onekey[1] == 'sequencing_setup'%}
                          <td>
@@ -75,7 +76,7 @@ Description: Shows a table with all worksets.
                      {% elif onekey[1] in ['passed', 'failed', 'unknown', 'total'] %}
                          <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td> 
                      {% elif onekey[1] == 'Workset Notes'%}
-                         <td class="latest_workset_note" class="text-center" style="min-width:250px">
+                         <td class="latest_workset_note" class="text-center" style="min-width:400px">
                          {% if ws_data[onews].get('Workset Notes') %}
                               {% set workset_notes = ws_data[onews].get('Workset Notes') %}
                               {% set latest_workset_note_key = list(workset_notes.keys())[0] %}

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -470,9 +470,6 @@ td.progress {
     margin-left:-650px;
     left: 50%;
 }
-/* workset project name colors */
-a.open_ws_link	{ color: #5d963c !important; }
-a.closed_ws_link	{ color: #7a7a7a !important; }
 /* Email list */
 .email_list {
     display: flex;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -470,6 +470,9 @@ td.progress {
     margin-left:-650px;
     left: 50%;
 }
+/* workset project name colors */
+a.open_ws_link	{ color: #5d963c !important; }
+a.closed_ws_link	{ color: #7a7a7a !important; }
 /* Email list */
 .email_list {
     display: flex;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -470,6 +470,20 @@ td.progress {
     margin-left:-650px;
     left: 50%;
 }
+/* workset project name colors */
+a.pending_ws_link	 { color: #0398fc !important; }
+
+a.rc_ws_link	 { color: #b103fc !important; }
+
+a.review_ws_link	{ color: #fc0303 !important; }
+
+a.ongoing_ws_link	{ color: #00ba0c !important; }
+
+a.open_ws_link	{ color: #ab9100 !important; }
+
+a.closed_ws_link	{ color: #808080 !important; }
+
+a.aborted_ws_link	{ color: #f73bdb !important; }
 /* Email list */
 .email_list {
     display: flex;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -470,20 +470,6 @@ td.progress {
     margin-left:-650px;
     left: 50%;
 }
-/* workset project name colors */
-a.pending_ws_link	 { color: #0398fc !important; }
-
-a.rc_ws_link	 { color: #b103fc !important; }
-
-a.review_ws_link	{ color: #fc0303 !important; }
-
-a.ongoing_ws_link	{ color: #00ba0c !important; }
-
-a.open_ws_link	{ color: #ab9100 !important; }
-
-a.closed_ws_link	{ color: #808080 !important; }
-
-a.aborted_ws_link	{ color: #f73bdb !important; }
 /* Email list */
 .email_list {
     display: flex;

--- a/run_dir/static/js/worksets.js
+++ b/run_dir/static/js/worksets.js
@@ -13,6 +13,18 @@ $(document).ready(function() {
 });
 
 function load_table() {
+      var tbl_row = $('<tr>');
+      var latest_ws_note = tbl_row.find('td.latest_workset_note');
+      if (latest_ws_note.text() !== '') {
+        var note = JSON.parse(latest_workset_note_key.text());
+        var ndate = undefined;
+        for (key in note) { ndate = key; break; }
+        notedate = new Date(ndate);
+        latest_ws_note.html('<div class="panel panel-default running-note-panel">' +
+        '<div class="panel-heading">'+
+          note[ndate]['user']+' - '+notedate.toDateString()+', ' + notedate.toLocaleTimeString(notedate)+
+        '</div><div class="panel-body">'+make_markdown(note[ndate]['note'])+'</pre></div></div>');
+        }
     init_listjs();
 }
 

--- a/run_dir/static/js/worksets.js
+++ b/run_dir/static/js/worksets.js
@@ -56,8 +56,17 @@ function init_listjs() {
             that
             .search( this.value )
             .draw();
-        } );
-    } );
+        });
+    });
+    // Copy workset table to clipboard
+    var clipboard = new Clipboard('#ws_copy_table');
+    clipboard.on('success', function(e) {
+      e.clearSelection();
+      $('#ws_copy_table').addClass('active').html('<span class="glyphicon glyphicon-copy"></span> Copied!');
+      setTimeout(function(){
+      $('#ws_copy_table').removeClass('active').html('<span class="glyphicon glyphicon-copy"></span> Copy table');
+      }, 2000);
+    });
 }
 
 function load_workset_notes(wait) {

--- a/status/worksets.py
+++ b/status/worksets.py
@@ -25,7 +25,7 @@ class WorksetsDataHandler(SafeHandler):
             result[row.key]=row.value
             result[row.key].pop("_id", None)
             result[row.key].pop("_rev", None)
-        self.write(json.dumps(result,result2))
+        self.write(json.dumps(result))
 
 class WorksetsHandler(SafeHandler):
     """Loaded through /worksets

--- a/status/worksets.py
+++ b/status/worksets.py
@@ -68,9 +68,9 @@ class WorksetsHandler(SafeHandler):
                  ['Projects (samples)','projects'],['Sequencing Setup', 'sequencing_setup'], \
                  ['Date finished', 'finish date'],['Operator', 'technician'], \
                  ['Application', 'application'],['Library','library_method'], \
-                 ['Samples Passed', 'passed'],['Latest workset note', 'Workset Notes'], \
-                 ['Samples Failed', 'failed'],['Pending Samples', 'unknown'], \
-                 ['Total samples', 'total']];
+                 ['Samples Passed', 'passed'],['Samples Failed', 'failed'] , \
+                 ['Pending Samples', 'unknown'],['Total samples', 'total'], \
+                 ['Latest workset note', 'Workset Notes']];
         self.write(t.generate(gs_globals=self.application.gs_globals, worksets=all, user=self.get_current_user(), ws_data=ws_data, headers=headers, all=all))
 
 class WorksetDataHandler(SafeHandler):
@@ -98,7 +98,7 @@ class WorksetDataHandler(SafeHandler):
             result[row.key].pop("_id", None)
             result[row.key].pop("_rev", None)
         return result
-
+    
 class WorksetHandler(SafeHandler):
     """Loaded through /workset/[workset]"""
     def get(self, workset):

--- a/status/worksets.py
+++ b/status/worksets.py
@@ -35,23 +35,28 @@ class WorksetsHandler(SafeHandler):
         result={}
         half_a_year_ago = datetime.datetime.now() - relativedelta(months=6)
         ws_view= self.application.worksets_db.view("worksets/summary", descending=True)
-
-            
+        def _get_latest_running_note(val):
+            notes = json.loads(val['Workset Notes'])
+            latest_note = { max(notes.keys()): notes[max(notes.keys())] }
+            return latest_note
         for row in ws_view:
             if all:
                 result[row.key]=row.value
                 result[row.key].pop("_id", None)
                 result[row.key].pop("_rev", None)
+                if 'Workset Notes' in row.value:
+                    result[row.key]['Workset Notes'] = _get_latest_running_note(row.value)
             else:
                 try:
                     if parse(row.value['date_run']) >= half_a_year_ago:
                         result[row.key]=row.value
                         result[row.key].pop("_id", None)
                         result[row.key].pop("_rev", None)
+                        if 'Workset Notes' in row.value:
+                            result[row.key]['Workset Notes'] = _get_latest_running_note(row.value)
                 # Exception that date_run is not available
                 except TypeError:
                     continue
-
         return result
 
     def get(self):
@@ -60,12 +65,12 @@ class WorksetsHandler(SafeHandler):
         t = self.application.loader.load("worksets.html")
         ws_data=self.worksets_data(all=all)
         headers= [['Date Run', 'date_run'],['Workset Name', 'workset_name'], \
-                 ['Projects (samples)','projects'], ['Sequencing Setup', 'sequencing_setup'], \
-                 ['Date finished', 'finish date'],['Operator', 'technician'],\
-                 ['Application', 'application'], ['Library','library_method'], \
-                 ['Samples Passed', 'passed'],['Samples Failed', 'failed'], \
-                 ['Pending Samples', 'unknown'], ['Total samples', 'total'], \
-                 ['Latest workset note', 'Workset Notes']];
+                 ['Projects (samples)','projects'],['Sequencing Setup', 'sequencing_setup'], \
+                 ['Date finished', 'finish date'],['Operator', 'technician'], \
+                 ['Application', 'application'],['Library','library_method'], \
+                 ['Samples Passed', 'passed'],['Latest workset note', 'Workset Notes'], \
+                 ['Samples Failed', 'failed'],['Pending Samples', 'unknown'], \
+                 ['Total samples', 'total']];
         self.write(t.generate(gs_globals=self.application.gs_globals, worksets=all, user=self.get_current_user(), ws_data=ws_data, headers=headers, all=all))
 
 class WorksetDataHandler(SafeHandler):

--- a/status/worksets.py
+++ b/status/worksets.py
@@ -20,12 +20,12 @@ class WorksetsDataHandler(SafeHandler):
     def get(self):
         self.set_header("Content-type", "application/json")
         ws_view= self.application.worksets_db.view("worksets/summary", descending=True)
-        result={}
+        result={} 
         for row in ws_view:
             result[row.key]=row.value
             result[row.key].pop("_id", None)
             result[row.key].pop("_rev", None)
-        self.write(json.dumps(result))
+        self.write(json.dumps(result,result2))
 
 class WorksetsHandler(SafeHandler):
     """Loaded through /worksets
@@ -36,6 +36,7 @@ class WorksetsHandler(SafeHandler):
         half_a_year_ago = datetime.datetime.now() - relativedelta(months=6)
         ws_view= self.application.worksets_db.view("worksets/summary", descending=True)
 
+            
         for row in ws_view:
             if all:
                 result[row.key]=row.value
@@ -63,7 +64,8 @@ class WorksetsHandler(SafeHandler):
                  ['Date finished', 'finish date'],['Operator', 'technician'],\
                  ['Application', 'application'], ['Library','library_method'], \
                  ['Samples Passed', 'passed'],['Samples Failed', 'failed'], \
-                 ['Pending Samples', 'unknown'], ['Total samples', 'total']];
+                 ['Pending Samples', 'unknown'], ['Total samples', 'total'], \
+                 ['Latest workset note', 'Workset Notes']];
         self.write(t.generate(gs_globals=self.application.gs_globals, worksets=all, user=self.get_current_user(), ws_data=ws_data, headers=headers, all=all))
 
 class WorksetDataHandler(SafeHandler):


### PR DESCRIPTION
WIth a lot of help from Anand I managed to add the latest workset note to the worksets table!  

Since there are so many columns in this table, I added the note to the far right of the "default view" of the screen, since I guess it's more valuable to see the latest workset note during the production meetings than the number of samples passed/failed/pending? To see these columns one can simply scroll to the right. However I'm open to suggestions, so if you want I could add the note to the far right (not visible in the "default view") as well.

It's on stage, since we're using tools-dev one has to click "all" (there is only one workset with a note :-))...