### PR TITLE
Usability improvements on the queue pages

### DIFF
--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -11,10 +11,10 @@ Description: Shows a table with all qPCR pools.
 
 <div class="container-fluid" id="qpcrpools_list">
   <div id="pools_table_div">
+      <label class="btn btn-sm btn-default expand-all pull-right"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <h1><span id="page_title">qPCR pools</span>
         <small>Showing all qPCR pools</small>
       </h1>
-      <label class="btn btn-sm btn-default expand-all"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
         <thead>
           <tr class="sticky">

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -14,7 +14,7 @@ Description: Shows a table with all qPCR pools.
       <h1><span id="page_title">qPCR pools</span>
         <small>Showing all qPCR pools</small>
       </h1>
-      <label class="btn btn-sm btn-default expand-all pull-right"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
+      <label class="btn btn-sm btn-default expand-all pull-right" style="margin-bottom: 2rem;"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
         <thead>
           <tr class="sticky">

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -41,7 +41,6 @@ Description: Shows a table with all qPCR pools.
 </div>
 
 <script src="/static/js/jquery.dataTables.min.js"></script>
-<script src="/static/js/dataTables.rowGroup.min.js"></script>
 <script src="/static/js/qpcr_pools.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -14,7 +14,7 @@ Description: Shows a table with all qPCR pools.
       <h1><span id="page_title">qPCR pools</span>
         <small>Showing all qPCR pools</small>
       </h1>
-      <label class="btn btn-sm btn-default expand-all pull-right" style="margin-bottom: 2rem;"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
+      <label class="btn btn-sm btn-default expand-all pull-right" style="margin-bottom: 1rem;"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
         <thead>
           <tr class="sticky">

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -11,10 +11,10 @@ Description: Shows a table with all qPCR pools.
 
 <div class="container-fluid" id="qpcrpools_list">
   <div id="pools_table_div">
-      <label class="btn btn-sm btn-default expand-all pull-right"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <h1><span id="page_title">qPCR pools</span>
         <small>Showing all qPCR pools</small>
       </h1>
+      <label class="btn btn-sm btn-default expand-all pull-right"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
         <thead>
           <tr class="sticky">

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -14,7 +14,8 @@ Description: Shows a table with all qPCR pools.
       <h1><span id="page_title">qPCR pools</span>
         <small>Showing all qPCR pools</small>
       </h1>
-      <table class="table table-striped table-bordered sortable" id="pools_table">
+      <label class="btn btn-sm btn-default expand-all"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
+      <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
         <thead>
           <tr class="sticky">
             <th class="sort"></th>

--- a/run_dir/design/sequencing_queues.html
+++ b/run_dir/design/sequencing_queues.html
@@ -14,7 +14,7 @@ Description: Shows a table with extant sequencing queues.
       <h1><span id="page_title">Sequencing queues</span>
         <small>Showing all sequencing queues</small>
       </h1>
-      <table class="table table-striped table-bordered sortable" id="queues_table">
+      <table class="table table-hover table-striped table-bordered sortable" id="queues_table">
         <thead>
           <tr class="sticky">
             <th class="sort"></th>

--- a/run_dir/design/sequencing_queues.html
+++ b/run_dir/design/sequencing_queues.html
@@ -50,7 +50,6 @@ Description: Shows a table with extant sequencing queues.
 </div>
 
 <script src="/static/js/jquery.dataTables.min.js"></script>
-<script src="/static/js/dataTables.rowGroup.min.js"></script>
 <script src="/static/js/sequencing_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -23,10 +23,10 @@ Description: Shows a table with all worksets.
         {% else %}
           <h2 id="{{ worksets }}" class="worksets_page_heading"> <small>Worksets from the last 6 months. </small><a class="btn btn-default" href="/worksets?all=True">Show all</a></h2>
         {% end %}
-        <div class="form-group">	
+        <div class="form-group">
 	      <button type="button" id="ws_copy_table" class="btn btn-sm btn-default" data-clipboard-target="#workset_table"><span class="glyphicon glyphicon-copy"></span> Copy table</button>
         </div>
-        <div id="workset-list">	
+        <div id="workset-list">
         &nbsp;
           <table class="table table-striped table-bordered sortable" id="workset_table">
             <thead id="workset_table_head">
@@ -78,7 +78,7 @@ Description: Shows a table with all worksets.
                          {% raw '</samp><hr style="margin:0;"><samp>'.join(ws_data[onews].get(onekey[1])) %}
                          </samp></td>
                      {% elif onekey[1] in ['passed', 'failed', 'unknown', 'total'] %}
-                         <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td> 
+                         <td>{{ ws_data[onews].get('samples', {}).get(onekey[1]) }}</td>
                      {% elif onekey[1] == 'Workset Notes'%}
                          <td class="latest_workset_note" class="text-center" style="min-width:400px">
                          {% if ws_data[onews].get('Workset Notes') %}
@@ -107,7 +107,8 @@ Description: Shows a table with all worksets.
       <div class="tab-pane fade" id="tab_pending_samples_to_worksets">
         <h2 class="worksets_page_heading"> <small>All samples that are available to be added to a workset in LIMS.</small></h2>
         <div id="samples-to-workset-list">
-          <table class="table table-striped table-bordered sortable" id="samples_table">
+          <label class="btn btn-sm btn-default expand-all"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
+          <table class="table table-hover table-striped table-bordered sortable" id="samples_table">
             <thead id="samples_table_head">
                 <tr class="sticky">
                   <th></th>

--- a/run_dir/design/worksets.html
+++ b/run_dir/design/worksets.html
@@ -105,9 +105,9 @@ Description: Shows a table with all worksets.
         </div>
       </div>
       <div class="tab-pane fade" id="tab_pending_samples_to_worksets">
+        <label class="btn btn-sm btn-default expand-all pull-right"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
         <h2 class="worksets_page_heading"> <small>All samples that are available to be added to a workset in LIMS.</small></h2>
         <div id="samples-to-workset-list">
-          <label class="btn btn-sm btn-default expand-all"><span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>Expand All</label>
           <table class="table table-hover table-striped table-bordered sortable" id="samples_table">
             <thead id="samples_table_head">
                 <tr class="sticky">

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -1208,6 +1208,10 @@ tr.group, tr.group:hover, .dtrg-group {
     cursor: pointer;
 }
 
+.expand-proj {
+  cursor: pointer;
+}
+
 .expand-proj span.glyphicon{
   color: #0088cc;
   cursor: pointer;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -1208,7 +1208,7 @@ tr.group, tr.group:hover, .dtrg-group {
     cursor: pointer;
 }
 
-.expand-proj{
+.expand-proj span.glyphicon{
   color: #0088cc;
   cursor: pointer;
   margin-right: 6px;
@@ -1217,4 +1217,10 @@ tr.group, tr.group:hover, .dtrg-group {
 /* Sequencing queues PAGE */
 .mult-pools-margin{
   margin-bottom: 2px;
+}
+
+.expand-all span.glyphicon{
+  color: #0088cc;
+  cursor: pointer;
+  margin-right: 4px;
 }

--- a/run_dir/static/js/qpcr_pools.js
+++ b/run_dir/static/js/qpcr_pools.js
@@ -21,9 +21,9 @@ function load_table() {
           var avg_wait_calc = 0;
           var tbl_row = $('<tr>');
           tbl_row.append($('<td>').html(flow));
-          tbl_row.append($('<td>').html(function() {
-              var to_return = '<span class="glyphicon glyphicon-plus-sign expand-proj" aria-hidden="true"></span>';
-              to_return = to_return + container + ' ('+pools['samples'].length+')';
+          tbl_row.append($('<td class="expand-proj">').html(function() {
+              var to_return = '<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>';
+              to_return = to_return + container + ' <span class="badge">'+pools['samples'].length+'</span>';
               to_return = to_return + '<BR><span> \
               <table cellpadding="5" border="0" style="visibility:collapse;margin-bottom:0px;margin-top:5px;" align="right">';
               to_return = to_return + '<thead><tr><th style="width:45%">Sample</th><th style="width:20%">Well</th><th>Waiting (in days)</th></tr></thead>';
@@ -33,7 +33,7 @@ function load_table() {
                 '<tr>'+
                   '<td>'+sample['name']+'</td>'+
                   '<td>'+sample['well']+'</td>'+
-                  '<td>'+ wait +'</td>'+
+                  '<td>'+wait+'</td>'+
                 '</tr>';
                 avg_wait_calc = avg_wait_calc + wait;
                 });
@@ -54,7 +54,13 @@ function load_table() {
             });
             return to_return;
           }));
-          tbl_row.append($('<td>').html((avg_wait_calc/pools['samples'].length).toFixed(1)));
+          var lblinf='';
+          switch(Math.floor((avg_wait_calc/pools['samples'].length)/7)){
+            case 0: lblinf = 'success'; break;
+            case 1: lblinf = 'warning'; break;
+            default: lblinf = 'danger';
+          }
+          tbl_row.append($('<td>').html('<span class="label label-'+lblinf+'">'+(avg_wait_calc/pools['samples'].length).toFixed(1)+'</span>'));
           $("#pools_table_body").append(tbl_row);
         })
       }
@@ -110,13 +116,23 @@ function init_listjs() {
     } );
     $('.expand-proj').on('click', function () {
       if($(this).parent().find('table').css('visibility')=='collapse'){
-        $(this).toggleClass('glypicon-plus-sign glyphicon-minus-sign');
+        $(this).find('.glyphicon').toggleClass('glyphicon-plus-sign glyphicon-minus-sign');
         $(this).parent().find('table').css('visibility', 'visible');
       }
       else {
-        $(this).toggleClass('glyphicon-minus-sign glypicon-plus-sign');
+        $(this).find('.glyphicon').toggleClass('glyphicon-minus-sign glyphicon-plus-sign');
         $(this).parent().find('table').css('visibility', 'collapse');
       }
+    });
+    $('.expand-all').on('click', function () {
+      var reqText = {'Expand All': ['Collapse All', 'visible', 'glyphicon-plus-sign', 'glyphicon-minus-sign'],
+                      'Collapse All': ['Expand All', 'collapse', 'glyphicon-minus-sign', 'glyphicon-plus-sign']};
+      $('.expand-all').find('.glyphicon').removeClass(reqText[$('.expand-all').text()][2]);
+      $('#pools_table').find('tr').find('.glyphicon').removeClass(reqText[$('.expand-all').text()][2]);
+      $('.expand-all').find('.glyphicon').addClass(reqText[$('.expand-all').text()][3]);
+      $('#pools_table').find('tr').find('.glyphicon').addClass(reqText[$('.expand-all').text()][3]);
+      $('#pools_table').find('tr').find('table').css('visibility', reqText[$('.expand-all').text()][1]);
+      $('.expand-all').contents().filter(function(){ return this.nodeType == 3; }).first().replaceWith(reqText[$('.expand-all').text()][0]);
     });
 }
 

--- a/run_dir/static/js/qpcr_pools.js
+++ b/run_dir/static/js/qpcr_pools.js
@@ -28,13 +28,14 @@ function load_table() {
               <table cellpadding="5" border="0" style="visibility:collapse;margin-bottom:0px;margin-top:5px;" align="right">';
               to_return = to_return + '<thead><tr><th style="width:45%">Sample</th><th style="width:20%">Well</th><th>Waiting (in days)</th></tr></thead>';
               $.each(pools['samples'], function(pool, sample){
-                var wait = Math.floor(Math.abs(new Date() - new Date(sample['queue_time']))/(1000*86400));
+                var wait = getDaysAndDateLabel(sample['queue_time'], 'date')[0];
                 to_return = to_return +
                 '<tr>'+
                   '<td>'+sample['name']+'</td>'+
                   '<td>'+sample['well']+'</td>'+
                   '<td>'+wait+'</td>'+
                 '</tr>';
+                //use avg_wait_calc as a counter
                 avg_wait_calc = avg_wait_calc + wait;
                 });
                 to_return = to_return +'</table></span>';
@@ -54,13 +55,10 @@ function load_table() {
             });
             return to_return;
           }));
-          var lblinf='';
-          switch(Math.floor((avg_wait_calc/pools['samples'].length)/7)){
-            case 0: lblinf = 'success'; break;
-            case 1: lblinf = 'warning'; break;
-            default: lblinf = 'danger';
-          }
-          tbl_row.append($('<td>').html('<span class="label label-'+lblinf+'">'+(avg_wait_calc/pools['samples'].length).toFixed(1)+'</span>'));
+          //get average wait time for all samples in a pool.
+          avg_wait_calc = avg_wait_calc/pools['samples'].length;
+          var daysAndLabel = getDaysAndDateLabel(avg_wait_calc, 'label');
+          tbl_row.append($('<td>').html('<span class="label label-'+daysAndLabel[1]+'">'+(avg_wait_calc).toFixed(1)+'</span>'));
           $("#pools_table_body").append(tbl_row);
         })
       }
@@ -139,3 +137,27 @@ function init_listjs() {
 $('body').on('click', '.group', function(event) {
   $($("#samples_table").DataTable().column(0).header()).trigger("click")
 });
+
+function getDaysAndDateLabel(date, option){
+  var number_of_days = 0;
+  var label = '';
+  if( option=='date' || option=='both' ){
+    //calculate number of days from given date to current date
+    number_of_days = Math.floor(Math.abs(new Date() - new Date(date))/(1000*86400));
+  }
+  if (option=='label' || option=='both') {
+    if (option=='label'){
+      number_of_days = date;
+    }
+    if (number_of_days < 7){
+      label =  'success';
+    }
+    else if (number_of_days >= 7 && number_of_days < 14) {
+      label = 'warning';
+    }
+    else {
+      label = 'danger';
+    }
+  }
+   return [number_of_days, label];
+}

--- a/run_dir/static/js/sequencing_queues.js
+++ b/run_dir/static/js/sequencing_queues.js
@@ -29,14 +29,8 @@ function load_table() {
               plate_value = '<div class="mult-pools-margin">'+plate+' <span class="label label-warning sentenceCase">Rerun</span></div>';
             }
             plates.push(plate_value);
-            var lblinf = '';
-            var wait_time = Math.floor(Math.abs(new Date() - new Date(values['queue_time']))/(1000*86400));
-            switch(Math.floor(wait_time/7)){
-              case 0: lblinf = 'success'; break;
-              case 1: lblinf = 'warning'; break;
-              default: lblinf = 'danger';
-            }
-            queuetimes.push('<div class="mult-pools-margin"><span class="label label-'+lblinf+'">'+wait_time+'</span></div>');
+            var daysAndLabel = getDaysAndDateLabel(values['queue_time'], 'both');
+            queuetimes.push('<div class="mult-pools-margin"><span class="label label-'+daysAndLabel[1]+'">'+daysAndLabel[0]+'</span></div>');
             qpcrconc.push('<div class="mult-pools-margin">'+values['conc_pool_qpcr']+'</div>');
           });
           tbl_row.append($('<td>').html(plates));
@@ -105,3 +99,27 @@ function init_listjs() {
 $('body').on('click', '.group', function(event) {
   $($("#queues_table").DataTable().column(0).header()).trigger("click")
 });
+
+function getDaysAndDateLabel(date, option){
+  var number_of_days = 0;
+  var label = '';
+  if( option=='date' || option=='both' ){
+    //calculate number of days from given date to current date
+    number_of_days = Math.floor(Math.abs(new Date() - new Date(date))/(1000*86400));
+  }
+  if (option=='label' || option=='both') {
+    if (option=='label'){
+      number_of_days = date;
+    }
+    if (number_of_days < 7){
+      label =  'success';
+    }
+    else if (number_of_days >= 7 && number_of_days < 14) {
+      label = 'warning';
+    }
+    else {
+      label = 'danger';
+    }
+  }
+   return [number_of_days, label];
+}

--- a/run_dir/static/js/sequencing_queues.js
+++ b/run_dir/static/js/sequencing_queues.js
@@ -29,7 +29,14 @@ function load_table() {
               plate_value = '<div class="mult-pools-margin">'+plate+' <span class="label label-warning sentenceCase">Rerun</span></div>';
             }
             plates.push(plate_value);
-            queuetimes.push('<div class="mult-pools-margin">'+Math.floor(Math.abs(new Date() - new Date(values['queue_time']))/(1000*86400)) + '</div>');
+            var lblinf = '';
+            var wait_time = Math.floor(Math.abs(new Date() - new Date(values['queue_time']))/(1000*86400));
+            switch(Math.floor(wait_time/7)){
+              case 0: lblinf = 'success'; break;
+              case 1: lblinf = 'warning'; break;
+              default: lblinf = 'danger';
+            }
+            queuetimes.push('<div class="mult-pools-margin"><span class="label label-'+lblinf+'">'+wait_time+'</span></div>');
             qpcrconc.push('<div class="mult-pools-margin">'+values['conc_pool_qpcr']+'</div>');
           });
           tbl_row.append($('<td>').html(plates));

--- a/run_dir/static/js/worksets.js
+++ b/run_dir/static/js/worksets.js
@@ -104,8 +104,8 @@ $(".tabbable").on("click", '[role="tab"]', function() {
           $.each(value, function(project, projval){
             var tbl_row = $('<tr>');
             tbl_row.append($('<td>').html(key));
-            tbl_row.append($('<td>').html(function() {
-              var to_return = '<span class="glyphicon glyphicon-plus-sign expand-proj" aria-hidden="true"></span>';
+            tbl_row.append($('<td class=" expand-proj">').html(function() {
+              var to_return = '<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>';
               to_return = to_return + '<a href="/project/'+project+'">'+projval['pname']+' ('+project+') </a>';
               to_return = to_return + '<span style="float:right; padding-right:50px;"><table cellpadding="5" border="0" style="visibility:collapse;">';
               to_return = to_return + '<thead><tr><th>Samples</th></tr></thead>';
@@ -118,10 +118,16 @@ $(".tabbable").on("click", '[role="tab"]', function() {
                 to_return = to_return +'</table></span>';
                 return to_return;
               }));
-            tbl_row.append($('<td>').html(projval['samples'].length +' ('+ projval['total_num_samples']+')'));
+            tbl_row.append($('<td>').html(projval['samples'].length +' <span class="badge">'+ projval['total_num_samples']+'</span>'));
             sumGroups[key] = sumGroups[key] + projval['samples'].length;
             var number_of_days = Math.floor(Math.abs(new Date() - new Date(projval['queued_date']))/(1000*86400));
-            tbl_row.append($('<td>').html(number_of_days));
+            var lblinf='';
+            switch(Math.floor(number_of_days/7)){
+              case 0: lblinf = 'success'; break;
+              case 1: lblinf = 'warning'; break;
+              default: lblinf = 'danger';
+            }
+            tbl_row.append($('<td>').html('<span class="label label-'+lblinf+'">'+number_of_days+'</span>'));
             $("#samples_table_body").append(tbl_row);
           });
         }
@@ -130,13 +136,23 @@ $(".tabbable").on("click", '[role="tab"]', function() {
       init_listjs2();
       $('.expand-proj').on('click', function () {
         if($(this).parent().find('table').css('visibility')=='collapse'){
-          $(this).toggleClass('glypicon-plus-sign glyphicon-minus-sign');
+          $(this).find('.glyphicon').toggleClass('glyphicon-plus-sign glyphicon-minus-sign');
           $(this).parent().find('table').css('visibility', 'visible');
         }
         else {
-          $(this).toggleClass('glyphicon-minus-sign glypicon-plus-sign');
+          $(this).find('.glyphicon').toggleClass('glyphicon-minus-sign glyphicon-plus-sign');
           $(this).parent().find('table').css('visibility', 'collapse');
         }
+      });
+      $('.expand-all').on('click', function () {
+        var reqText = {'Expand All': ['Collapse All', 'visible', 'glyphicon-plus-sign', 'glyphicon-minus-sign'],
+                        'Collapse All': ['Expand All', 'collapse', 'glyphicon-minus-sign', 'glyphicon-plus-sign']};
+        $('.expand-all').find('.glyphicon').removeClass(reqText[$('.expand-all').text()][2]);
+        $('#samples_table').find('tr').find('.glyphicon').removeClass(reqText[$('.expand-all').text()][2]);
+        $('.expand-all').find('.glyphicon').addClass(reqText[$('.expand-all').text()][3]);
+        $('#samples_table').find('tr').find('.glyphicon').addClass(reqText[$('.expand-all').text()][3]);
+        $('#samples_table').find('tr').find('table').css('visibility', reqText[$('.expand-all').text()][1]);
+        $('.expand-all').contents().filter(function(){ return this.nodeType == 3; }).first().replaceWith(reqText[$('.expand-all').text()][0]);
       });
     });
   }

--- a/run_dir/static/js/worksets.js
+++ b/run_dir/static/js/worksets.js
@@ -104,7 +104,7 @@ $(".tabbable").on("click", '[role="tab"]', function() {
           $.each(value, function(project, projval){
             var tbl_row = $('<tr>');
             tbl_row.append($('<td>').html(key));
-            tbl_row.append($('<td class=" expand-proj">').html(function() {
+            tbl_row.append($('<td class="expand-proj">').html(function() {
               var to_return = '<span class="glyphicon glyphicon-plus-sign" aria-hidden="true"></span>';
               to_return = to_return + '<a href="/project/'+project+'">'+projval['pname']+' ('+project+') </a>';
               to_return = to_return + '<span style="float:right; padding-right:50px;"><table cellpadding="5" border="0" style="visibility:collapse;">';
@@ -120,14 +120,8 @@ $(".tabbable").on("click", '[role="tab"]', function() {
               }));
             tbl_row.append($('<td>').html(projval['samples'].length +' <span class="badge">'+ projval['total_num_samples']+'</span>'));
             sumGroups[key] = sumGroups[key] + projval['samples'].length;
-            var number_of_days = Math.floor(Math.abs(new Date() - new Date(projval['queued_date']))/(1000*86400));
-            var lblinf='';
-            switch(Math.floor(number_of_days/7)){
-              case 0: lblinf = 'success'; break;
-              case 1: lblinf = 'warning'; break;
-              default: lblinf = 'danger';
-            }
-            tbl_row.append($('<td>').html('<span class="label label-'+lblinf+'">'+number_of_days+'</span>'));
+            var daysAndLabel = getDaysAndDateLabel(projval['queued_date'], 'both');
+            tbl_row.append($('<td>').html('<span class="label label-'+daysAndLabel[1]+'">'+daysAndLabel[0]+'</span>'));
             $("#samples_table_body").append(tbl_row);
           });
         }
@@ -224,3 +218,27 @@ function init_listjs2() {
 $('body').on('click', '.group', function(event) {
   $($("#samples_table").DataTable().column(0).header()).trigger("click")
 });
+
+function getDaysAndDateLabel(date, option){
+  var number_of_days = 0;
+  var label = '';
+  if( option=='date' || option=='both' ){
+    //calculate number of days from given date to current date
+    number_of_days = Math.floor(Math.abs(new Date() - new Date(date))/(1000*86400));
+  }
+  if (option=='label' || option=='both') {
+    if (option=='label'){
+      number_of_days = date;
+    }
+    if (number_of_days < 7){
+      label =  'success';
+    }
+    else if (number_of_days >= 7 && number_of_days < 14) {
+      label = 'warning';
+    }
+    else {
+      label = 'danger';
+    }
+  }
+   return [number_of_days, label];
+}


### PR DESCRIPTION
Based on Phil's suggestions as below

- Make the whole table cell clickable, or at least the name. Not just the + icon
- Use labels for the sample count information
- Have buttons at the top of the page to expand-all and collapse-all rows
- Add table-hover class to tables so that it's easier to follow the rows with the mouse cursor
- Use coloured labels to give visual indication of how old the wait time is

Available on genstat-stage!
