### PR TITLE
Add unique headings to running notes

### DIFF
--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -51,7 +51,8 @@ function make_running_note(date, note){
         } else {
           noteText = '<pre class="plaintext_running_note">'+make_project_links(note['note'])+'</pre>';
         }
-        datestring = date.toDateString() + ', ' + date.toLocaleTimeString(date)
+        datestring = date.toDateString() + ', ' + date.toLocaleTimeString(date);
+	note_id = 'running_note_'+date.getTime();
         if ('category' in note){
             category=generate_category_label(note['category']);
         }
@@ -66,9 +67,9 @@ function make_running_note(date, note){
     panelClass = 'panel-important';
   }
   return '<div class="panel panel-default">' +
-      '<div class="panel-heading '+panelClass+'">'+
+      '<div class="panel-heading '+panelClass+'" id="'+note_id+'">'+
         '<a href="mailto:' + note['email'] + '">'+note['user']+'</a> - '+
-       datestring + printHyphen +category +'</div><div class="panel-body">'+noteText+'</div></div>';
+       '<a href="#'+note_id+'">' + datestring + '</a>' + printHyphen +category +'</div><div class="panel-body">'+noteText+'</div></div>';
 }
 
 function load_running_notes(wait) {


### PR DESCRIPTION
Should add a unique link like `#running_note_2345678` to every running note. Click the date in the running note heading to jump to it and copy the URL.