### PR TITLE
Added function for sending Slack IM to user being tagged in a running note

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -19,6 +19,7 @@ PyYAML==5.1
 requests>=2.14.2
 simplejson>=3.10.0
 six>=1.10.0
+slackclient
 tornado>=6.0.2
 utils>=0.9.0
 Zenpy

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ logbook
 cffi
 matplotlib>=2.0.0
 markdown
+nest_asyncio
 numpy>=1.12.1
 oauth2>=1.9.0.post1
 paramiko>=2.1.2

--- a/status/projects.py
+++ b/status/projects.py
@@ -700,24 +700,24 @@ class RunningNotesDataHandler(SafeHandler):
                 client = slack.WebClient(token=application.slack_token)
 
                 blocks = [
-                            {
-                              "type": "section",
-		                      "text": {
-                                "type": "mrkdwn",
-        		                "text": ("_You have been tagged by *{}* in a running note for the project_ "
-                                       "<{}/project/{}|{}>! :smile: \n_The note is as follows:_ \n\n\n")
-                                        .format(tagger, application.settings['redirect_uri'].rsplit('/',1)[0], project, project) 
-                               }
-                            },
-                            {
-                              "type": "section",
-                              "text": {
-                                "type": "mrkdwn",
-                                "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack."
-                                      " It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
-         	                   }
-                            }
-                         ]
+                    {
+                        "type": "section",
+		                "text": {
+                            "type": "mrkdwn",
+        		            "text": ("_You have been tagged by *{}* in a running note for the project_ "
+                                     "<{}/project/{}|{}>! :smile: \n_The note is as follows:_ \n\n\n")
+                             .format(tagger, application.settings['redirect_uri'].rsplit('/',1)[0], project, project) 
+                        }
+                    },
+                    {
+                        "type": "section",
+                        "text": {
+                            "type": "mrkdwn",
+                            "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack."
+                            " It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
+         	            }
+                     }
+                ]
 
                 userid = client.users_lookupByEmail(email=view_result[user])
                 channel = client.conversations_open(users=userid.data['user']['id'])

--- a/status/projects.py
+++ b/status/projects.py
@@ -691,7 +691,7 @@ class RunningNotesDataHandler(SafeHandler):
                 msg.attach(MIMEText(text, 'plain'))
                 msg.attach(MIMEText(html, 'html'))
 
-                s = smtplib.SMTP('localhost', 1025)
+                s = smtplib.SMTP('localhost')
                 s.sendmail('genomics-bioinfo@scilifelab.se', msg['To'], msg.as_string())
                 s.quit()
 
@@ -700,21 +700,23 @@ class RunningNotesDataHandler(SafeHandler):
                 client = slack.WebClient(token=application.slack_token)
 
                 blocks = [
-                                  {
-                                    "type": "section",
-		                            "text": {
-                                    "type": "mrkdwn",
-        		                    "text": ("_You have been tagged by *{}* in a running note for the project_ <https://genomics-status.scilifelab.se/project/{}|{}>! :smile: \n"
-                                             "_The note is as follows:_ \n\n\n").format(tagger, project, project) 
-                                    }
-                                  },
-                                  {
-                                    "type": "section",
-                                    "text": {
-                                    "type": "mrkdwn",
-                                    "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack. It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
-         	                        }
-                                  }                               
+                            {
+                              "type": "section",
+		                      "text": {
+                              "type": "mrkdwn",
+        		              "text": ("_You have been tagged by *{}* in a running note for the project_ "
+                                       "<{}/project/{}|{}>! :smile: \n_The note is as follows:_ \n\n\n")
+                                        .format(tagger, application.settings['redirect_uri'].rsplit('/',1)[0], project, project) 
+                              }
+                            },
+                            {
+                              "type": "section",
+                              "text": {
+                              "type": "mrkdwn",
+                              "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack."
+                                      " It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
+         	                  }
+                            }
                          ]
 
                 userid = client.users_lookupByEmail(email=view_result[user])

--- a/status/projects.py
+++ b/status/projects.py
@@ -703,19 +703,19 @@ class RunningNotesDataHandler(SafeHandler):
                             {
                               "type": "section",
 		                      "text": {
-                              "type": "mrkdwn",
-        		              "text": ("_You have been tagged by *{}* in a running note for the project_ "
+                                "type": "mrkdwn",
+        		                "text": ("_You have been tagged by *{}* in a running note for the project_ "
                                        "<{}/project/{}|{}>! :smile: \n_The note is as follows:_ \n\n\n")
                                         .format(tagger, application.settings['redirect_uri'].rsplit('/',1)[0], project, project) 
-                              }
+                               }
                             },
                             {
                               "type": "section",
                               "text": {
-                              "type": "mrkdwn",
-                              "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack."
+                                "type": "mrkdwn",
+                                "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack."
                                       " It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
-         	                  }
+         	                   }
                             }
                          ]
 

--- a/status/projects.py
+++ b/status/projects.py
@@ -18,6 +18,8 @@ import smtplib
 from email.mime.text import MIMEText
 from email.mime.multipart import MIMEMultipart
 import markdown
+import slack
+import nest_asyncio
 
 #from itertools import ifilter
 from collections import defaultdict
@@ -689,10 +691,36 @@ class RunningNotesDataHandler(SafeHandler):
                 msg.attach(MIMEText(text, 'plain'))
                 msg.attach(MIMEText(html, 'html'))
 
-                s = smtplib.SMTP('localhost')
+                s = smtplib.SMTP('localhost', 1025)
                 s.sendmail('genomics-bioinfo@scilifelab.se', msg['To'], msg.as_string())
                 s.quit()
 
+                #Adding a slack IM to the tagged user with the running note
+                nest_asyncio.apply()
+                client = slack.WebClient(token=application.slack_token)
+
+                blocks = [
+                                  {
+                                    "type": "section",
+		                            "text": {
+                                    "type": "mrkdwn",
+        		                    "text": ("_You have been tagged by *{}* in a running note for the project_ <https://genomics-status.scilifelab.se/project/{}|{}>! :smile: \n"
+                                             "_The note is as follows:_ \n\n\n").format(tagger, project, project) 
+                                    }
+                                  },
+                                  {
+                                    "type": "section",
+                                    "text": {
+                                    "type": "mrkdwn",
+                                    "text": ">*{} - {}{}*\n>{}\n\n\n\n _(Please do not respond to this message here in Slack. It will only be seen by you.)_".format(tagger, time_in_format, category, note.replace('\n', '\n>'))
+         	                        }
+                                  }                               
+                         ]
+
+                userid = client.users_lookupByEmail(email=view_result[user])
+                channel = client.conversations_open(users=userid.data['user']['id'])
+                client.chat_postMessage(channel=channel.data['channel']['id'], blocks=blocks)
+                client.conversations_close(channel=channel.data['channel']['id'])
 
 class LinksDataHandler(SafeHandler):
     """ Serves external links for each project

--- a/status_app.py
+++ b/status_app.py
@@ -298,6 +298,9 @@ class Application(tornado.web.Application):
         self.trello_api_secret = settings['trello']['api_secret']
         self.trello_token = settings['trello']['token']
 
+        # Slack
+        self.slack_token = settings['slack']['token']
+
         # Load password seed
         self.password_seed = settings.get("password_seed")
 


### PR DESCRIPTION
So I created a Slack bot (app) to send an IM to the user being tagged in a running note in GenStat (based on the e-mail list in StatusDB). The user will receive a message with the running note, the project, the user that tagged him or her, as well as the time and date of the running note.

It is currently not possible to respond to the message in Slack, but one could click on the project ID and be directed to the project page in GenStat.

Someone (Anand or Sara?) still needs to set up the settings file to include the token info.

Not sure if we want the functionality to switch between Slack and e-mail or if we should always receive both e-mail and Slack message? If we want to be able to choose between Slack and e-mail we need to create a settings page in GenStat I guess?