### PR TITLE
Update authorization parameters

### DIFF
--- a/status/authorization.py
+++ b/status/authorization.py
@@ -37,8 +37,7 @@ class LoginHandler(tornado.web.RequestHandler, tornado.auth.GoogleOAuth2Mixin):
                         redirect_uri=self.application.settings['redirect_uri'],
                         client_id=self.application.oauth_key,
                         scope=['profile', 'email'],
-                        response_type='code',
-                        extra_params={'approval_prompt': 'auto'})
+                        response_type='code')
 
 class LogoutHandler(tornado.web.RequestHandler, tornado.auth.GoogleOAuth2Mixin):
     def get(self):


### PR DESCRIPTION
I didn't add the new parameter ('prompt') in the end because Google says 
>If you don't specify this parameter, the user will be prompted only the first time your project requests access.

which seems ok.