### PR TITLE
Make Customer names for projects searchable and switch to replicated db for views

### DIFF
--- a/status/projects.py
+++ b/status/projects.py
@@ -332,7 +332,7 @@ class ProjectsBaseDataHandler(SafeHandler):
         t_threshold = datetime.datetime.now() - relativedelta(minutes=3)
         if ProjectsBaseDataHandler.cached_search_list is None or \
                 ProjectsBaseDataHandler.search_list_last_fetched < t_threshold:
-            projects_view = self.application.projects_db.view("projects/name_to_id", descending=True)
+            projects_view = self.application.projects_db_views.view("projects/name_to_id_cust_ref", descending=True)
 
             ProjectsBaseDataHandler.cached_search_list = [(row.key, row.value) for row in projects_view]
             ProjectsBaseDataHandler.search_list_last_fetched = datetime.datetime.now()
@@ -340,10 +340,10 @@ class ProjectsBaseDataHandler(SafeHandler):
         search_string = search_string.lower()
 
         for row_key, row_value in ProjectsBaseDataHandler.cached_search_list:
-            if search_string in row_key.lower() or search_string in row_value.lower():
+            if search_string in row_key.lower() or search_string in row_value[0].lower() or (row_value[1] and search_string in row_value[1].lower()):
                 project = {
-                    "url": '/project/'+row_value,
-                    "name": "{} ({})".format(row_key, row_value)
+                    "url": '/project/'+row_value[0],
+                    "name": "{} ({})".format(row_key, row_value[0])
                 }
                 projects.append(project)
 

--- a/status_app.py
+++ b/status_app.py
@@ -245,6 +245,7 @@ class Application(tornado.web.Application):
             self.pricing_exchange_rates_db = couch["pricing_exchange_rates"]
             self.pricing_products_db = couch["pricing_products"]
             self.projects_db = couch["projects"]
+            self.projects_db_views = couch["projects_new"] #added because some views are timimg out in projects db but not in this one replicated from it
             self.samples_db = couch["samples"]
             self.server_status_db = couch['server_status']
             self.suggestions_db = couch["suggestion_box"]


### PR DESCRIPTION
As some views aren't working properly on the original projects db in couchdb and I am hesitant to delete data, I replicated it to a new db on the same server where the views seem to work.

It's a stopgap measure while we figure out how to solve the couchdb issue.