### PR TITLE
Speedup Bioinfo deliveries page

### DIFF
--- a/status/deliveries.py
+++ b/status/deliveries.py
@@ -68,7 +68,8 @@ class DeliveriesPageHandler(SafeHandler):
 
     def get(self):
         # get project summary data
-        summary_view = self.application.projects_db.view('project/summary')
+        summary_view = self.application.projects_db.view('project/summary', descending=True)
+        summary_view = summary_view[["open",'Z']:["open",'']]
         summary_data = {}
         for project in summary_view:
             # todo: check if this one works


### PR DESCRIPTION
Applies same shortcut to get only open projects (as in the `projects.py` script) which speeds the page up a little. The speeded up version of the Bioinfo page with both this change and the `project_closed` field in statusdb can be seen on stage!