### PR TITLE
Fix integration tests

### DIFF
--- a/run_dir/static/js/index.js
+++ b/run_dir/static/js/index.js
@@ -11,9 +11,6 @@ fill_updates_table = function(){
             } else if(summary[2] == 'Flowcell information'){
                 link = '<a href="/flowcells/'+summary[1]+'">';
                 linkend = '</a>';
-            } else if(summary[2] == 'Sample information'){
-                link = '<a href="/samples/'+summary[1]+'">';
-                linkend = '</a>';
             }
             tbl_row = '<tr>';
         tbl_row += '<td>' + link + summary[2] + linkend + '</td>';
@@ -47,7 +44,7 @@ fill_updates_table = function(){
         }
     });
 };
-    
+
 
 $(document).ready(function(){
     fill_updates_table();

--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -125,6 +125,10 @@ function generateQuoteList() {
               warning_txt = `Quantity for ` + product.Name + ` is not a multiple of its minimum quantity: ` + product["Minimum Quantity"]
           }
       }
+      if (product["Status"] == 'Discontinued') {
+          class_string = ' class="text-danger"'
+          warning_txt = 'Discontinued product: ' + product.Name + ' included in the current quote.'
+      }
       empty = false;
       var li = `<li data-quantity=${product.quantity}` + class_string + ` data-product-id=${product_id}>` +
         `<a href='#' class='remove_product' data-product-id=${product.REF_ID}><i class="glyphicon glyphicon-remove text-danger"></i></a> ` +

--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -125,10 +125,6 @@ function generateQuoteList() {
               warning_txt = `Quantity for ` + product.Name + ` is not a multiple of its minimum quantity: ` + product["Minimum Quantity"]
           }
       }
-      if (product["Status"] == 'Discontinued') {
-          class_string = ' class="text-danger"'
-          warning_txt = 'Discontinued product: ' + product.Name + ' included in the current quote.'
-      }
       empty = false;
       var li = `<li data-quantity=${product.quantity}` + class_string + ` data-product-id=${product_id}>` +
         `<a href='#' class='remove_product' data-product-id=${product.REF_ID}><i class="glyphicon glyphicon-remove text-danger"></i></a> ` +

--- a/status/projects.py
+++ b/status/projects.py
@@ -398,7 +398,7 @@ class ProjectsFieldsDataHandler(ProjectsBaseDataHandler):
     """
     def get(self):
         undefined = self.get_argument("undefined", "False")
-        undefined = (string.lower(undefined) == "true")
+        undefined = (undefined.lower() == "true")
         project_list = self.get_argument("project_list", "all")
         field_items = self.list_project_fields(undefined=undefined, project_list=project_list)
         self.write(json.dumps(list(field_items)))

--- a/status/projects.py
+++ b/status/projects.py
@@ -1,7 +1,6 @@
 """ Handlers for sequencing project information.
 """
 import json
-import string
 import traceback
 
 import tornado.web

--- a/status/queues.py
+++ b/status/queues.py
@@ -48,7 +48,10 @@ class qPCRPoolsDataHandler(SafeHandler):
                     library_type = ''
                     runmode = ''
                     if not 'lambda DNA' in art.name:
-                        library_type = art.samples[0].project.udf["Library construction method"]
+                        try:
+                            library_type = art.samples[0].project.udf["Library construction method"]
+                        except KeyError:  # I think this was an issue on stage with strange data
+                            library_type = 'NA'
                         try:
                             runmode = art.samples[0].project.udf['Sequencing platform']
                         except KeyError:

--- a/status/queues.py
+++ b/status/queues.py
@@ -48,10 +48,7 @@ class qPCRPoolsDataHandler(SafeHandler):
                     library_type = ''
                     runmode = ''
                     if not 'lambda DNA' in art.name:
-                        try:
-                            library_type = art.samples[0].project.udf["Library construction method"]
-                        except KeyError:  # I think this was an issue on stage with strange data
-                            library_type = 'NA'
+                        library_type = art.samples[0].project.udf.get("Library construction method", 'NA')
                         try:
                             runmode = art.samples[0].project.udf['Sequencing platform']
                         except KeyError:

--- a/status/samples.py
+++ b/status/samples.py
@@ -40,15 +40,6 @@ class SampleQCSummaryDataHandler(SafeHandler):
         return result.rows[0].value
 
 
-class SampleRunHandler(SafeHandler):
-    """ Serves a page of brief statistics and sample runs of a given sample.
-    """
-    def get(self, sample):
-        t = self.application.loader.load("sample_runs.html")
-        self.write(t.generate(gs_globals=self.application.gs_globals, sample=sample, user= self.get_current_user(),
-                              deprecated=True))
-
-
 class SampleRunDataHandler(SafeHandler):
     """ Serves a list of sample runs for a given sample.
 
@@ -80,16 +71,6 @@ class SampleQCDataHandler(SafeHandler):
         result = self.application.samples_db.view("qc/qc_summary")[sample]
 
         return result.rows[0].value
-
-
-class SampleQCSummaryHandler(SafeHandler):
-    """ Serves a page which displays QC data with tables and plots for a
-    given sample run.
-    """
-    def get(self, sample):
-        t = self.application.loader.load("sample_run_qc.html")
-        self.write(t.generate(gs_globals=self.application.gs_globals, sample=sample, user= self.get_current_user(),
-                              deprecated=True))
 
 
 class SampleQCAlignmentDataHandler(SafeHandler):
@@ -171,15 +152,6 @@ class SamplesPerLaneDataHandler(SafeHandler):
             samples_per_lane.append(row.value)
 
         return samples_per_lane
-
-
-class SamplesPerLaneHandler(SafeHandler):
-    """ Serves a page which displays a plot for the number of samples
-    loaded on a lane.
-    """
-    def get(self):
-        t = self.application.loader.load("samples_per_lane.html")
-        self.write(t.generate(gs_globals=self.application.gs_globals, user=self.get_current_user(), deprecated=True))
 
 
 class SamplesPerLanePlotHandler(SamplesPerLaneDataHandler):

--- a/status/sequencing.py
+++ b/status/sequencing.py
@@ -73,7 +73,7 @@ class InstrumentClusterDensityPlotHandler(InstrumentClusterDensityDataHandler):
                     upper.append(np.percentile(errors, 25))
                     lower.append(np.percentile(errors, 75))
 
-                except ValueError:
+                except IndexError:  # Empty list
                     continue
 
             c_ax = ax[i]

--- a/status/util.py
+++ b/status/util.py
@@ -239,11 +239,6 @@ class UpdatedDocumentsDatahandler(SafeHandler):
     def list_updated(self, num_items=25):
         last = []
 
-        view = self.application.samples_db.view("time/last_updated",
-                                                limit=num_items, descending=True)
-        for doc in view:
-            last.append((doc.key, doc.value, 'Sample information'))
-
         view = self.application.projects_db.view("time/last_updated",
                                                  limit=num_items, descending=True)
         for doc in view:

--- a/status/util.py
+++ b/status/util.py
@@ -208,9 +208,14 @@ class DataHandler(UnsafeHandler):
     """
     def get(self):
         self.set_header("Content-type", "application/json")
-        handlers = [h[0] for h in self.application.declared_handlers]
+        handlers = []
+        for h in self.application.declared_handlers:
+            try:
+                handlers.append(h[0])
+            except TypeError:  # 'URLSpec' object does not support indexing
+                handlers.append(h.regex.pattern)
         api = [h for h in handlers if h.startswith("/api")]
-        utils = [h for h in handlers if h == "/login" or h == "/logout"]
+        utils = [h for h in handlers if h == "/login" or h == "/logout" or h == ".*"]
         pages = list(set(handlers).difference(set(api)).difference(set(utils)))
         pages = [h for h in pages if not (h.endswith("?") or h.endswith("$"))]
         pages.sort(reverse=True)

--- a/status/util.py
+++ b/status/util.py
@@ -273,11 +273,6 @@ class PagedQCDataHandler(SafeHandler):
 
         return sample_list
 
-class SafeStaticFileHandler(SafeHandler, tornado.web.StaticFileHandler):
-    """ Serve static files for authenticated users
-    """
-    pass
-
 
 class NoCacheStaticFileHandler(tornado.web.StaticFileHandler):
     """ Serves up static files without any tornado caching.

--- a/status_app.py
+++ b/status_app.py
@@ -54,7 +54,7 @@ from status.statistics import YearApplicationsProjectHandler, YearApplicationsSa
     ApplicationOpenProjectsHandler, ApplicationOpenSamplesHandler, WeekInstrumentTypeYieldHandler, StatsAggregationHandler, YearDeliverytimeApplicationHandler
 from status.suggestion_box import SuggestionBoxDataHandler, SuggestionBoxHandler
 from status.testing import TestDataHandler
-from status.util import BaseHandler, DataHandler, LastPSULRunHandler, MainHandler, PagedQCDataHandler, SafeStaticFileHandler, \
+from status.util import BaseHandler, DataHandler, LastPSULRunHandler, MainHandler, PagedQCDataHandler, \
     UpdatedDocumentsDatahandler
 from status.user_preferences import UserPrefPageHandler
 from status.worksets import WorksetHandler, WorksetsHandler, WorksetDataHandler, WorksetLinksHandler, WorksetNotesDataHandler, \
@@ -204,7 +204,6 @@ class Application(tornado.web.Application):
             ("/multiqc_report/([^/]*)$", MultiQCReportHandler),
             ("/nas_quotas", NASQuotasHandler),
             ("/qc/([^/]*)$", SampleQCSummaryHandler),
-            (r"/qc_reports/(.*)", SafeStaticFileHandler, {"path": 'qc_reports'}),
             ("/pools_qpcr", qPCRPoolsHandler),
             ("/pricing_products", PricingProductListHandler),
             ("/pricing_quote", PricingQuoteHandler),

--- a/status_app.py
+++ b/status_app.py
@@ -44,9 +44,9 @@ from status.nas_quotas import NASQuotasHandler
 from status.queues import qPCRPoolsDataHandler, qPCRPoolsHandler, SequencingQueuesDataHandler, SequencingQueuesHandler
 from status.reads_plot import DataFlowcellYieldHandler, FlowcellPlotHandler, FlowcellCountPlotHandler, FlowcellCountApiHandler
 from status.samples import SampleInfoDataHandler, SampleQCAlignmentDataHandler, SampleQCCoverageDataHandler, \
-    SampleQCDataHandler, SampleQCInsertSizesDataHandler, SampleQCSummaryDataHandler, SampleQCSummaryHandler, \
-    SampleReadCountDataHandler, SampleRunDataHandler, SampleRunHandler, SampleRunReadCountDataHandler, SamplesPerLaneDataHandler, \
-    SamplesPerLaneHandler, SamplesPerLanePlotHandler
+    SampleQCDataHandler, SampleQCInsertSizesDataHandler, SampleQCSummaryDataHandler, \
+    SampleReadCountDataHandler, SampleRunDataHandler, SampleRunReadCountDataHandler, SamplesPerLaneDataHandler, \
+    SamplesPerLanePlotHandler
 from status.sequencing import InstrumentClusterDensityPlotHandler, InstrumentErrorratePlotHandler, InstrumentUnmatchedPlotHandler, \
     InstrumentYieldPlotHandler, InstrumentClusterDensityDataHandler, InstrumentErrorrateDataHandler, InstrumentUnmatchedDataHandler, \
     InstrumentYieldDataHandler
@@ -203,7 +203,6 @@ class Application(tornado.web.Application):
             ("/instrument_logs/([^/]*)$", InstrumentLogsHandler),
             ("/multiqc_report/([^/]*)$", MultiQCReportHandler),
             ("/nas_quotas", NASQuotasHandler),
-            ("/qc/([^/]*)$", SampleQCSummaryHandler),
             ("/pools_qpcr", qPCRPoolsHandler),
             ("/pricing_products", PricingProductListHandler),
             ("/pricing_quote", PricingQuoteHandler),
@@ -216,7 +215,6 @@ class Application(tornado.web.Application):
             ("/proj_meta", ProjMetaCompareHandler),
             ("/reads_total/([^/]*)$", ReadsTotalHandler),
             ("/rec_ctrl_view/([^/]*)$", RecCtrlDataHandler),
-            ("/samples/([^/]*)$", SampleRunHandler),
             ("/sequencing_queues", SequencingQueuesHandler),
             ("/suggestion_box", SuggestionBoxHandler),
             ("/userpref", UserPrefPageHandler),

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -105,7 +105,7 @@ class TestGet(object):
         url = self.url + '/api/v1/'
         urls = [url + 'quotas/' + quota_id]
 
-        error_pages = filter(lambda u: not requests.get(u).ok, urls)
+        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
         assert_true(len(error_pages) == 0,
                     msg=('Quota requests resulted in error {0} '.format(error_pages)))
 
@@ -126,12 +126,12 @@ class TestGet(object):
                 url + 'flowcell_info/' + flowcell_id,
                 url + 'flowcell_demultiplex/' + flowcell_id]
 
-        error_pages = filter(lambda u: not requests.get(u).ok, urls)
+        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
         assert_true(len(error_pages) == 0,
                     msg=('Flowcell requests resulted in error {0} '.format(error_pages)))
 
         non_error_url = filter(lambda u: u not in error_pages,  urls)
-        empty_json = filter(lambda u: len(json.loads(requests.get(u).content)) == 0, non_error_url)
+        empty_json = list(filter(lambda u: len(json.loads(requests.get(u).content)) == 0, non_error_url))
         assert_true(len(empty_json) == 0,
                     msg=('Flowcell requests are empty: {0} '.format(empty_json)))
 
@@ -149,11 +149,11 @@ class TestGet(object):
         urls = [url + 'project_summary/' + project_id,
                 url + 'application/' + application]
 
-        error_pages = filter(lambda u: not requests.get(u).ok, urls)
+        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
         assert_true(len(error_pages) == 0,
                     msg=('Misc requests resulted in error {0} '.format(error_pages)))
 
         non_error_url = filter(lambda u: u not in error_pages,  urls)
-        empty_json = filter(lambda u: len(json.loads(requests.get(u).content)) == 0, non_error_url)
+        empty_json = list(filter(lambda u: len(json.loads(requests.get(u).content)) == 0, non_error_url))
         assert_true(len(empty_json) == 0,
                     msg=('Misc requests are empty: {0} '.format(empty_json)))

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -58,84 +58,18 @@ class TestGet(object):
 
     def test_api_samples(self):
         """ Testing:
-        '/api/v1/samples/start/([^/]*)$'
-        '/api/v1/samples/([^/]*)$',
-        '/api/v1/sample_summary/([^/]*)$',
-        '/api/v1/sample_run_counts/(\\w+)?',
-        '/api/v1/sample_readcount/(\\w+)?',
-        '/api/v1/sample_insert_sizes/([^/]*)$',
         '/api/v1/sample_info/([^/]*)$',
-        '/api/v1/sample_coverage/([^/]*)$',
-        '/api/v1/sample_alignment/([^/]*)$',
-        '/api/v1/qc/([^/]*)$'
         """
         sample_id1 = self.test_items['samples']['sample_id1']
         sample_id2 = self.test_items['samples']['sample_id2']
-        sample_run_id = self.test_items['samples']['sample_run_id']
 
         url = self.url + '/api/v1/'
-        urls = [url + 'samples/start/' + sample_id1,
-                url + 'samples/start/' + sample_id2,
-                url + 'samples/' + sample_id1,
-                url + 'samples/' + sample_id2,
-                url + 'sample_summary/' + sample_run_id,
-                url + 'sample_run_counts/' + sample_id1,
-                url + 'sample_run_counts/' + sample_id2,
-                url + 'sample_readcount/' + sample_id1,
-                url + 'sample_readcount/' + sample_id2,
-                url + 'sample_insert_sizes/' + sample_run_id,
-                url + 'sample_info/' + sample_id1,
-                url + 'sample_info/' + sample_id2,
-                url + 'sample_coverage/' + sample_run_id,
-                url + 'sample_alignment/' + sample_run_id,
-                url + 'qc/' + sample_run_id]
+        urls = [url + 'sample_info/' + sample_id1,
+                url + 'sample_info/' + sample_id2]
 
         error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
         assert_true(len(error_pages) == 0,
                     msg=('Sample requests resulted in error {0} '.format(error_pages)))
-
-    def test_api_quotas(self):
-        """ Testing:
-
-        '/api/v1/quotas/(\\w+)?'
-
-        """
-
-        quota_id = self.test_items['quota']['quota_id']
-        url = self.url + '/api/v1/'
-        urls = [url + 'quotas/' + quota_id]
-
-        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
-        assert_true(len(error_pages) == 0,
-                    msg=('Quota requests resulted in error {0} '.format(error_pages)))
-
-
-    def test_api_flowcells(self):
-        """" Testing:
-        '/api/v1/flowcells/([^/]*)$'
-        '/api/v1/flowcell_qc/([^/]*)$',
-        '/api/v1/flowcell_q30/([^/]*)$',
-        '/api/v1/flowcell_info/([^/]*)$',
-        '/api/v1/flowcell_demultiplex/([^/]*)$',
-        """
-        flowcell_id = self.test_items['flowcells']['flowcell_id']
-        url = self.url + '/api/v1/'
-        urls = [url + 'flowcells/' + flowcell_id,
-                url + 'flowcell_qc/' + flowcell_id,
-                url + 'flowcell_q30/' + flowcell_id,
-                url + 'flowcell_info/' + flowcell_id,
-                url + 'flowcell_demultiplex/' + flowcell_id]
-
-        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
-        assert_true(len(error_pages) == 0,
-                    msg=('Flowcell requests resulted in error {0} '.format(error_pages)))
-
-        non_error_url = filter(lambda u: u not in error_pages,  urls)
-        empty_json = list(filter(lambda u: len(json.loads(requests.get(u).content)) == 0, non_error_url))
-        assert_true(len(empty_json) == 0,
-                    msg=('Flowcell requests are empty: {0} '.format(empty_json)))
-
-
 
     def test_api_misc(self):
         """ Testing:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -37,9 +37,15 @@ class TestGet(object):
         no_regexp_pages = filter(lambda x: have_regexp.match(x) is None,
                                  pages)
 
+        ignore_pages = ['/api/v1/deliveries/set_bioinfo_responsible$',  # Never meant to be a api-get URL
+                        '/api/v1/bioinfo_analysis',  # Never meant to be a api-get URL
+                        '/api/v1/sequencing_queues' # lims-heavy request, refuses connection eventually
+                        ]
+        no_regexp_pages = [x for x in no_regexp_pages if x not in ignore_pages]
+
         # Check every url, that it gives a 200 OK response
-        error_pages = filter(lambda u: not requests.get(self.url + u).ok,
-                             no_regexp_pages)
+        error_pages = list(filter(lambda u: not requests.get(self.url + u).ok,
+                             no_regexp_pages))
 
         assert_true(len(error_pages) == 0,
                     msg=('Requests resulted in error: {0} '.format(error_pages)))
@@ -84,7 +90,7 @@ class TestGet(object):
                 url + 'sample_alignment/' + sample_run_id,
                 url + 'qc/' + sample_run_id]
 
-        error_pages = filter(lambda u: not requests.get(u).ok, urls)
+        error_pages = list(filter(lambda u: not requests.get(u).ok, urls))
         assert_true(len(error_pages) == 0,
                     msg=('Sample requests resulted in error {0} '.format(error_pages)))
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -15,7 +15,7 @@ class TestGet(object):
         """Server Settings"""
         self.url = 'http://localhost:9761'
         self.api = requests.get(self.url + '/api/v1')
-        #assert_true(self.api.ok)
+        assert_true(self.api.ok)
         with open(TEST_ITEMS) as test_items:
             self.test_items = yaml.load(test_items, Loader=yaml.SafeLoader)
 


### PR DESCRIPTION
Updated the test_integration.py:
 - Now works with python 3.
 - Avoids some problematic URLs
 - Removed calls to outdated URLs (mainly to the old flowcells_db and the old samples_db)

Also removed api URL:s that were only fetching from the samples database (it has not been updated for 4 years now).
