### PR TITLE
No regeneration of cookie secret

### DIFF
--- a/status_app.py
+++ b/status_app.py
@@ -319,10 +319,9 @@ class Application(tornado.web.Application):
         self.multiqc_path = settings.get('multiqc_path')
 
         # Setup the Tornado Application
-        cookie_secret = base64.b64encode(uuid.uuid4().bytes + uuid.uuid4().bytes)
+
         settings["debug"]= True
         settings["static_path"]= "static"
-        settings["cookie_secret"]= cookie_secret
         settings["login_url"]= "/login"
 
 
@@ -384,6 +383,10 @@ if __name__ == '__main__':
         server_settings = yaml.full_load(settings_file)
 
     server_settings["Testing mode"] = options['testing_mode']
+
+    if 'cookie_secret' not in server_settings:
+        cookie_secret = base64.b64encode(uuid.uuid4().bytes + uuid.uuid4().bytes)
+        server_settings['cookie_secret'] = cookie_secret
 
     # Instantiate Application
     application = Application(server_settings)

--- a/status_app.py
+++ b/status_app.py
@@ -374,6 +374,8 @@ if __name__ == '__main__':
                                                 "for testing purposes"))
     define('develop', default=False, help=("Define develop mode to look for changes "
                                            "in files and automatically reloading them"))
+
+    define('port', default=9761, type=int, help="The port that the server will listen to.")
     # After parsing the command line, the command line flags are stored in tornado.options
     tornado.options.parse_command_line()
 
@@ -400,7 +402,7 @@ if __name__ == '__main__':
     http_server = tornado.httpserver.HTTPServer(application,
                                                 ssl_options = ssl_options)
 
-    http_server.listen(server_settings.get("port", 8888))
+    http_server.listen(options["port"])
 
     # Get a handle to the instance of IOLoop
     ioloop = tornado.ioloop.IOLoop.instance()


### PR DESCRIPTION
+ Possible to specify port on the command line

Both actions in order to prepare for multiple instances of genstat running behind a load balancer.