### PR TITLE
Bug fix for pricing

### DIFF
--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -18,7 +18,7 @@ $( document ).ready(function() {
           $(that).html(original_html);
           $("#exch_rate_modal").modal('hide');
           generateQuoteList();
-          /* Fetch used exchange rate to update html*/
+          /* Fetch used exchange rate to update html */
           $.getJSON('/api/v1/pricing_exchange_rates?date='+date, function(data){
               $("#exch_rate_usd").text(parseFloat(data['USD_in_SEK']).toFixed(2));
               $("#exch_rate_eur").text(parseFloat(data['EUR_in_SEK']).toFixed(2));
@@ -61,20 +61,24 @@ $( document ).ready(function() {
 });
 
 function tableLoad(date=null, products=null, discontinued=false, _callback=null) {
-  // Table is loaded dynamically to enable switching of exchange rate date
-  products_tbody_url = '/pricing_quote_tbody'
-  products_url = '/api/v1/pricing_products'
+  // Table is loaded dynamically to enable switching of e.g. exchange rate date
+  products_tbody_url = '/pricing_quote_tbody';
+  products_tbody_par = new URLSearchParams();
+  products_url = '/api/v1/pricing_products';
+  products_par = new URLSearchParams();
+  products_par.append('discontinued', true);
 
   if (date !== null){
-      products_tbody_url += '?date=' + date
-      products_url += '?date=' + date
+      products_tbody_par.append('date', date);
+      products_par.append('date', date);
   };
 
   if (discontinued) {
-      products_tbody_url += '?discontinued=true'
-      products_url += '?disctontinued=true'
+      products_tbody_par.append('discontinued', true);
   };
 
+  products_tbody_url += '?' + products_tbody_par.toString();
+  products_url += '?' + products_par.toString();
   $('#pricing_products_tbody').load(products_tbody_url, function(){
     $.getJSON(products_url, function(data){
       allProducts = data;

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -277,7 +277,7 @@ class PricingBaseHandler(SafeHandler):
         return return_d
 
     def get_product_prices(self, product_id, version=None, date=None,
-                           discontinued=None, pretty_strings=False):
+                           discontinued=False, pretty_strings=False):
         """Calculate the price for an individual or all products
 
         :param product_id: The id of the product to calculate price for.
@@ -371,7 +371,7 @@ class PricingProductsDataHandler(PricingBaseHandler):
         """Returns individual or all products from the database as json"""
         version = self.get_argument('version', None)
         date = self.get_argument('date', None)
-        discontinued = self.get_argument('discontinued', None)
+        discontinued = self.get_argument('discontinued', False)
 
         rows = self.get_product_prices(search_string, version=version,
                                        date=date,

--- a/tests/test_pricing_integration.py
+++ b/tests/test_pricing_integration.py
@@ -108,6 +108,15 @@ class TestPricingQuote(unittest.TestCase):
         products_new_date = self.driver.find_elements(By.CSS_SELECTOR, '#pricing_products_tbody tr')
         self.assertEqual(len(all_products), len(products_new_date), msg="Changing date should not change discontinued")
 
+        discontinued_product = self.driver.find_elements(By.CSS_SELECTOR, '#pricing_products_tbody tr.status_discontinued')[0]
+        discontinued_product_name = discontinued_product.find_elements(By.CSS_SELECTOR, 'td.name')[0].text
+        discontinued_product.find_elements(By.CSS_SELECTOR, 'td a.add-to-quote')[0].click()
+        time.sleep(1)
+        quote_elements = self.driver.find_elements(By.CSS_SELECTOR, ".quote-product-list li > .quote_product_name")
+
+        self.assertEqual(len(quote_elements), 1, msg="Discontinued product should be added to the quote.")
+
+
 
 class TestApi(unittest.TestCase):
 


### PR DESCRIPTION
1. Discontinued products was not possible to add to the quote (simple typo: `'?disctontinued=true'`)
2. The new functionality for discontinued products broke the exchange rate functionality. Had to be smarter about appending URL parameters