### PR TITLE
Running notes design update

### DIFF
--- a/run_dir/design/running_notes_tab.html
+++ b/run_dir/design/running_notes_tab.html
@@ -6,11 +6,25 @@
                 <div class="panel-heading">Add New Running Note</div>
                 <div class="panel-body">
                     <div class="row">
-                        <div class="col-md-6">
+                        <div class="col-md-7 form-inline">
+                          <label>Choose category:</label>
+                          <div class="btn-toolbar" data-toggle="buttons" style="margin-top:5px">
+                             <button class="btn btn-xs btn-info btnCatFilter" value="Decision" data-toggle="tooltip" title="Use this category when an executive decision has been made">Decision &nbsp;<span class="fa fa-thumbs-up"</span></button>
+                             <button class="btn btn-xs btn-success btnCatFilter" value="Lab" data-toggle="tooltip" title="Use this category for lab-related work">Lab &nbsp;<span class="fa fa-bong"</span></button>
+                             <button class="btn btn-xs btn-warning btnCatFilter" value="Bioinformatics" data-toggle="tooltip" title="Use this category for all bioinformatics work">Bioinformatics &nbsp;<span class="fa fa-laptop-code"</span></button>
+                             <button class="btn btn-xs btn-usr btnCatFilter" value="User Communication" data-toggle="tooltip" title="Use this category for notes influenced by user-contact">User Communication &nbsp;<span class="fa fa-people-arrows"</span></button>
+                             <button class="btn btn-xs btn-danger btnCatFilter" value="Administration" data-toggle="tooltip" title="Use this category for notes involving documentation">Administration &nbsp;<span class="fa fa-folder-open"</span></button>
+                             <button class="btn btn-xs btn-imp btnCatFilter" value="Important" data-toggle="tooltip" title="Use this category when a note needs to be highlighted">Important &nbsp;<span class="fa fa-exclamation-circle"</span></button>
+                             <button class="btn btn-xs btn-devi btnCatFilter" value="Deviation" data-toggle="tooltip" title="Use this category for notes about a deviation">Deviation &nbsp;<span class="fa fa-frown"</span></button>
+                          </div>
+                        </div>
+                    </div>
+                    <div class="row">
+                        <div class="col-md-6" style="margin-top:20px;">
                             <h4>Write Running Note</h4>
                             <textarea rows="5" class="form-control" id="new_note_text" style="height:97px;"></textarea>
                         </div>
-                        <div class="col-md-6">
+                        <div class="col-md-6" style="margin-top:20px;">
                             <h4>Preview</h4>
                             <div class="panel panel-default" id="running_note_preview_panel">
                                 <div class="panel-heading"><a href="#">{{ user.name }}</a> - <span class="todays_date">Date</span><span id="preview_category"> - Category</span></div>
@@ -20,23 +34,6 @@
                             </div>
                         </div>
                     </div>
-
-                    <div class="row" style="margin-top:15px;">
-                        <div class="col-md-6 form-inline">
-                            <label>Category :</label>
-                            <select name="rn_cat" class="form-control" id="rn_category">
-                                <option value="Workset">Workset</option>
-                                <option value="Flowcell">Flowcell</option>
-                                <option value="Meeting">Meeting</option>
-                                <option value="Decision">Decision</option>
-                                <option value="Bioinformatics">Bioinformatics</option>
-                                <option value="User Communication">User Communication</option>
-                                <option value="Invoicing">Invoicing</option>
-                                <option value="Important">Important</option>
-                                <option value="Deviation">Deviation</option>
-                                <option value="" selected="selected">None</option>
-                            </select>
-                        </div>
                         <div class="col-md-6 text-right">
                             <button type="button" class="btn btn-link" data-toggle="modal" data-target="#markdown_help">Markdown Help</button>
                             <button type="submit" class="btn btn-primary" id="save_note_button">Submit Running Note</button>
@@ -51,19 +48,22 @@
             <label>Search :</label>
             <input type="text" class="form-control" id="rn_search" size=30 />
             <label>Filter :</label>
-            <button id="rn_cat_all" type="button" class="btn btn-xs btnCatFilter glow">All</button>
-            <button id="rn_cat_workset" type="button" class="btn btn-xs btn-primary btnCatFilter">Workset</button>
-            <button id="rn_cat_flowcell" type="button" class="btn btn-xs btn-success btnCatFilter">Flowcell</button>
-            <button id="rn_cat_meeting" type="button" class="btn btn-xs btn-info btnCatFilter">Meeting</button>
-            <button id="rn_cat_decision" type="button" class="btn btn-xs btn-info btnCatFilter">Decision</button>
-            <button id="rn_cat_bioinfo" type="button" class="btn btn-xs btn-warning btnCatFilter">Bioinformatics</button>
-            <button id="rn_cat_uscom" type="button" class="btn btn-xs btn-danger btnCatFilter">User Communication</button>
-            <button id="rn_cat_uscom" type="button" class="btn btn-xs btn-danger btnCatFilter">Invoicing</button>
-            <button id="rn_cat_imp" type="button" class="btn btn-xs btn-imp btnCatFilter">Important</button>
-            <button id="rn_cat_devi" type="button" class="btn btn-xs btn-devi btnCatFilter">Deviation</button>
+            <select class="form-control" id="rn_category">
+            <option value="All">All</option>
+            <option value="Workset">Workset</option>
+            <option value="Flowcell">Flowcell</option>
+            <option value="Decision">Decision</option>
+            <option value="Bioinformatics">Bioinformatics</option>
+            <option value="User Communication">User Communication</option>
+            <option value="Administration">Administration</option>
+            <option value="Important">Important</option>
+            <option value="Deviation">Deviation</option>
+            <option value="Lab">Lab</option>
+            </select>
         </div>
         <!-- display running notes -->
         <div class="panel-group" id="running_notes_panels"></div>
     </div>
     <script src="/static/js/jquery.caretposition.js"></script>
     <script src="/static/js/jquery.sew.js"></script>
+    <script src="https://kit.fontawesome.com/778b59723b.js" crossorigin="anonymous"></script>

--- a/run_dir/design/running_notes_tab.html
+++ b/run_dir/design/running_notes_tab.html
@@ -8,9 +8,9 @@
                     <div class="row">
                         <div class="col-md-7 form-inline">
                           <label>Choose category:</label>
-                          <div class="btn-toolbar rn-cat-filter" data-toggle="buttons" style="margin-top:5px">
+                          <div class="btn-toolbar rn-categ" data-toggle="buttons" style="margin-top:5px">
                              <button class="btn btn-xs btn-info" value="Decision" data-toggle="tooltip" title="For when an executive decision has been made">Decision <span class="fa fa-thumbs-up"</span></button>
-                             <button class="btn btn-xs btn-success" value="Lab" data-toggle="tooltip" title="For lab-related work">Lab <span class="fa fa-bong"</span></button>
+                             <button class="btn btn-xs btn-success" value="Lab" data-toggle="tooltip" title="For lab-related work">Lab <span class="fa fa-flask"</span></button>
                              <button class="btn btn-xs btn-warning" value="Bioinformatics" data-toggle="tooltip" title="For all bioinformatics work">Bioinformatics <span class="fa fa-laptop-code"</span></button>
                              <button class="btn btn-xs btn-usr" value="User Communication" data-toggle="tooltip" title="For notes influenced by user-contact">User Communication <span class="fa fa-people-arrows"</span></button>
                              <button class="btn btn-xs btn-danger" value="Administration" data-toggle="tooltip" title="For notes involving documentation">Administration <span class="fa fa-folder-open"</span></button>

--- a/run_dir/design/running_notes_tab.html
+++ b/run_dir/design/running_notes_tab.html
@@ -38,9 +38,8 @@
                             <button type="button" class="btn btn-link" data-toggle="modal" data-target="#markdown_help">Markdown Help</button>
                             <button type="submit" class="btn btn-primary" id="save_note_button">Submit Running Note</button>
                         </div>
-                    </div>
-                </div>
-            </div>
+                  </div>
+              </div>
         </form>
 
         <!-- filter running notes -->

--- a/run_dir/design/running_notes_tab.html
+++ b/run_dir/design/running_notes_tab.html
@@ -8,14 +8,14 @@
                     <div class="row">
                         <div class="col-md-7 form-inline">
                           <label>Choose category:</label>
-                          <div class="btn-toolbar" data-toggle="buttons" style="margin-top:5px">
-                             <button class="btn btn-xs btn-info btnCatFilter" value="Decision" data-toggle="tooltip" title="Use this category when an executive decision has been made">Decision &nbsp;<span class="fa fa-thumbs-up"</span></button>
-                             <button class="btn btn-xs btn-success btnCatFilter" value="Lab" data-toggle="tooltip" title="Use this category for lab-related work">Lab &nbsp;<span class="fa fa-bong"</span></button>
-                             <button class="btn btn-xs btn-warning btnCatFilter" value="Bioinformatics" data-toggle="tooltip" title="Use this category for all bioinformatics work">Bioinformatics &nbsp;<span class="fa fa-laptop-code"</span></button>
-                             <button class="btn btn-xs btn-usr btnCatFilter" value="User Communication" data-toggle="tooltip" title="Use this category for notes influenced by user-contact">User Communication &nbsp;<span class="fa fa-people-arrows"</span></button>
-                             <button class="btn btn-xs btn-danger btnCatFilter" value="Administration" data-toggle="tooltip" title="Use this category for notes involving documentation">Administration &nbsp;<span class="fa fa-folder-open"</span></button>
-                             <button class="btn btn-xs btn-imp btnCatFilter" value="Important" data-toggle="tooltip" title="Use this category when a note needs to be highlighted">Important &nbsp;<span class="fa fa-exclamation-circle"</span></button>
-                             <button class="btn btn-xs btn-devi btnCatFilter" value="Deviation" data-toggle="tooltip" title="Use this category for notes about a deviation">Deviation &nbsp;<span class="fa fa-frown"</span></button>
+                          <div class="btn-toolbar rn-cat-filter" data-toggle="buttons" style="margin-top:5px">
+                             <button class="btn btn-xs btn-info" value="Decision" data-toggle="tooltip" title="For when an executive decision has been made">Decision <span class="fa fa-thumbs-up"</span></button>
+                             <button class="btn btn-xs btn-success" value="Lab" data-toggle="tooltip" title="For lab-related work">Lab <span class="fa fa-bong"</span></button>
+                             <button class="btn btn-xs btn-warning" value="Bioinformatics" data-toggle="tooltip" title="For all bioinformatics work">Bioinformatics <span class="fa fa-laptop-code"</span></button>
+                             <button class="btn btn-xs btn-usr" value="User Communication" data-toggle="tooltip" title="For notes influenced by user-contact">User Communication <span class="fa fa-people-arrows"</span></button>
+                             <button class="btn btn-xs btn-danger" value="Administration" data-toggle="tooltip" title="For notes involving documentation">Administration <span class="fa fa-folder-open"</span></button>
+                             <button class="btn btn-xs btn-imp" value="Important" data-toggle="tooltip" title="For when a note needs to be highlighted">Important <span class="fa fa-exclamation-circle"</span></button>
+                             <button class="btn btn-xs btn-devi" value="Deviation" data-toggle="tooltip" title="For notes about a deviation">Deviation <span class="fa fa-frown"</span></button>
                           </div>
                         </div>
                     </div>
@@ -49,16 +49,16 @@
             <input type="text" class="form-control" id="rn_search" size=30 />
             <label>Filter :</label>
             <select class="form-control" id="rn_category">
-            <option value="All">All</option>
-            <option value="Workset">Workset</option>
-            <option value="Flowcell">Flowcell</option>
-            <option value="Decision">Decision</option>
-            <option value="Bioinformatics">Bioinformatics</option>
-            <option value="User Communication">User Communication</option>
-            <option value="Administration">Administration</option>
-            <option value="Important">Important</option>
-            <option value="Deviation">Deviation</option>
-            <option value="Lab">Lab</option>
+            <option>All</option>
+            <option>Workset</option>
+            <option>Flowcell</option>
+            <option>Decision</option>
+            <option>Bioinformatics</option>
+            <option>User Communication</option>
+            <option>Administration</option>
+            <option>Important</option>
+            <option>Deviation</option>
+            <option>Lab</option>
             </select>
         </div>
         <!-- display running notes -->
@@ -66,4 +66,3 @@
     </div>
     <script src="/static/js/jquery.caretposition.js"></script>
     <script src="/static/js/jquery.sew.js"></script>
-    <script src="https://kit.fontawesome.com/778b59723b.js" crossorigin="anonymous"></script>

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -168,6 +168,7 @@ table.narrow-headers th { width: 20%; }
 .label-date  {color: #333; font-size:80%; }
 .label-imp  {background-color: #a62100;}
 .label-devi  {background-color: #a13a7e;}
+.label-usr  {background-color: #ff6f00;}
 /* Date sliders */
 .slider-spacing { margin:40px 0; }
 
@@ -408,6 +409,14 @@ td.progress {
 .btn-devi:focus, .btn-devi:hover {
   color: #fff;
   background-color: #a13a7e;
+}
+.btn-usr{
+  color: #fff;
+  background-color: #ff6f00;
+}
+.btn-usr:focus, .btn-usr:hover {
+  color: #fff;
+  background-color: #ff6f00;
 }
 #markdown_help table td {
   width:50%;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -404,10 +404,10 @@ td.progress {
   color: #fff;
   background-color: #ff6f00;
 }
-.rn-cat-filter button span{
+.rn-categ button span{
     margin-left: 0.5rem;
 }
-.rn-cat-filter button:focus, .rn-cat-filter button:hover{
+.rn-categ button:focus, .rn-categ button:hover{
   color: #000;
   border-color: #000;
 }

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -392,13 +392,7 @@ td.progress {
 .btn-imp{
   color: #fff;
   background-color: #a62100;
-  border-color: #571100;
  }
-.btn-imp:focus, .btn-imp:hover {
-  color: #fff;
-  background-color: #8a1b00;
-  border-color: #8a1b00;
-}
 .panel-important{
   background-color: #ffd9d9 !important;
 }
@@ -406,17 +400,13 @@ td.progress {
   color: #fff;
   background-color: #a13a7e;
 }
-.btn-devi:focus, .btn-devi:hover {
-  color: #fff;
-  background-color: #a13a7e;
-}
 .btn-usr{
   color: #fff;
   background-color: #ff6f00;
 }
-.btn-usr:focus, .btn-usr:hover {
-  color: #fff;
-  background-color: #ff6f00;
+.btnCatFilter:focus, .btnCatFilter:hover {
+  color: #000;
+  border-color: #000;
 }
 #markdown_help table td {
   width:50%;

--- a/run_dir/static/css/status.css
+++ b/run_dir/static/css/status.css
@@ -404,7 +404,10 @@ td.progress {
   color: #fff;
   background-color: #ff6f00;
 }
-.btnCatFilter:focus, .btnCatFilter:hover {
+.rn-cat-filter button span{
+    margin-left: 0.5rem;
+}
+.rn-cat-filter button:focus, .rn-cat-filter button:hover{
   color: #000;
   border-color: #000;
 }

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -7,25 +7,28 @@ $(function(){
     });
 });
 
-function generate_category_label(category){
-   if (category == 'Decision'){
-        category='<span class="label label-info">'+ category +"</span>";
-    }else if (category == 'Lab'){
-        category='<span class="label label-success">'+ category +"</span>";
-    }else if (category == 'Bioinformatics'){
-        category='<span class="label label-warning">'+ category +"</span>";
-    }else if (category == 'User Communication'){
-        category='<span class="label label-usr">'+ category +"</span>";
-    }else if (category == 'Administration'){
-        category='<span class="label label-danger">'+ category +"</span>";
-    }else if (category == 'Important'){
-        category='<span class="label label-imp">'+ category +"</span>";
-    }else if (category == 'Deviation'){
-        category='<span class="label label-devi">'+ category +"</span>";
-    }else if (category != ''){
-        category='<span class="label label-default">'+ category +"</span>";
+function generate_category_label(cat_label){
+     var cat_classes = {
+        'Workset': ['primary', 'calendar-plus'],
+        'Flowcell': ['success', 'grip-vertical'],
+        'Decision': ['info', 'thumbs-up'],
+        'Lab': ['success', 'bong'],
+        'Bioinformatics': ['warning', 'laptop-code'],
+        'User Communication': ['usr', 'people-arrows'],
+        'Administration': ['danger', 'folder-open'],
+        'Important': ['imp', 'exclamation-circle'],
+        'Deviation': ['devi', 'frown']
     }
-    return category;
+    // Remove the whitespace
+    var cat_label = cat_label.trim()
+    // Check if we recognise this category in the class object keys
+    if (Object.keys(cat_classes).indexOf(cat_label) != -1){
+        cat_label = '<span class="label label-'+ cat_classes[cat_label][0] +'">'+ cat_label + '&nbsp;' + '<span class="fa fa-'+ cat_classes[cat_label][1] +'">'+"</span>";
+    }else{
+    // Default button formatting
+        cat_label = '<span class="label label-default">'+ cat_label +"</span>";
+    }
+    return cat_label;
 }
 
 function get_note_url() {
@@ -118,7 +121,7 @@ function load_running_notes(wait) {
 function preview_running_notes(){
     var now = new Date();
     $('.todays_date').text(now.toDateString() + ', ' + now.toLocaleTimeString());
-    var category = generate_category_label($('.btnCatFilter.active').val());
+    var category = generate_category_label($('.rn-cat-filter button.active').text());
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
@@ -161,34 +164,36 @@ $(document).ready(function() {
 });
 
 // Update the category buttons
-$('.btnCatFilter').click(function(){
+$('.rn-cat-filter button').click(function(){
     var was_selected = $(this).hasClass('active');
-    $('.btnCatFilter').removeClass('active');
-    if(!was_selected){ $(this).addClass('active'); }
-    });
+    $('.rn-cat-filter button').removeClass('active');
+    if(!was_selected){
+        $(this).addClass('active');
+    }
+    preview_running_notes();
+});
 
 //Remove hover text from clicked button
 $(document).ready(function(){
-       $('[data-toggle="tooltip"]').click(function () {
-          $('[data-toggle="tooltip"]').tooltip("hide");
-       });
+      $('[data-toggle="tooltip"]').click(function (){
+         $('[data-toggle="tooltip"]').tooltip("hide");
+      });
 })
 
 // Preview running notes
 $('#new_note_text').keyup(preview_running_notes);
-$('.btnCatFilter').click(preview_running_notes);
 
 // Insert new running note and reload the running notes table
 $("#running_notes_form").submit( function(e) {
     e.preventDefault();
     var text = $('#new_note_text').val().trim();
     text = $('<div>').text(text).html();
-    var category = $('.btnCatFilter.active').val();
+    var category = $('.rn-cat-filter button.active').text();
     if (text.length == 0) {
         alert("Error: No running note entered.");
         return false;
     }
-    if (!$('.btnCatFilter.active').val()) {
+    if (!$('.rn-cat-filter button.active').text()) {
        if (!confirm("Are you sure that you want to submit without choosing a category?")) {
           return false;
        }

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -7,12 +7,12 @@ $(function(){
     });
 });
 
-function generate_category_label(cat_label){
+function generate_category_label(category){
      var cat_classes = {
         'Workset': ['primary', 'calendar-plus'],
         'Flowcell': ['success', 'grip-vertical'],
         'Decision': ['info', 'thumbs-up'],
-        'Lab': ['success', 'bong'],
+        'Lab': ['success', 'flask'],
         'Bioinformatics': ['warning', 'laptop-code'],
         'User Communication': ['usr', 'people-arrows'],
         'Administration': ['danger', 'folder-open'],
@@ -20,13 +20,13 @@ function generate_category_label(cat_label){
         'Deviation': ['devi', 'frown']
     }
     // Remove the whitespace
-    var cat_label = cat_label.trim()
+    var category = category.trim()
     // Check if we recognise this category in the class object keys
-    if (Object.keys(cat_classes).indexOf(cat_label) != -1){
-        cat_label = '<span class="label label-'+ cat_classes[cat_label][0] +'">'+ cat_label + '&nbsp;' + '<span class="fa fa-'+ cat_classes[cat_label][1] +'">'+"</span>";
+    if (Object.keys(cat_classes).indexOf(category) != -1){
+        cat_label = '<span class="label label-'+ cat_classes[category][0] +'">'+ category + '&nbsp;' + '<span class="fa fa-'+ cat_classes[category][1] +'">'+"</span>";
     }else{
     // Default button formatting
-        cat_label = '<span class="label label-default">'+ cat_label +"</span>";
+        cat_label = '<span class="label label-default">'+ category +"</span>";
     }
     return cat_label;
 }
@@ -121,7 +121,7 @@ function load_running_notes(wait) {
 function preview_running_notes(){
     var now = new Date();
     $('.todays_date').text(now.toDateString() + ', ' + now.toLocaleTimeString());
-    var category = generate_category_label($('.rn-cat-filter button.active').text());
+    var category = generate_category_label($('.rn-categ button.active').text());
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
@@ -164,9 +164,9 @@ $(document).ready(function() {
 });
 
 // Update the category buttons
-$('.rn-cat-filter button').click(function(){
+$('.rn-categ button').click(function(){
     var was_selected = $(this).hasClass('active');
-    $('.rn-cat-filter button').removeClass('active');
+    $('.rn-categ button').removeClass('active');
     if(!was_selected){
         $(this).addClass('active');
     }
@@ -188,12 +188,12 @@ $("#running_notes_form").submit( function(e) {
     e.preventDefault();
     var text = $('#new_note_text').val().trim();
     text = $('<div>').text(text).html();
-    var category = $('.rn-cat-filter button.active').text();
+    var category = $('.rn-categ button.active').text();
     if (text.length == 0) {
         alert("Error: No running note entered.");
         return false;
     }
-    if (!$('.rn-cat-filter button.active').text()) {
+    if (!$('.rn-categ button.active').text()) {
        if (!confirm("Are you sure that you want to submit without choosing a category?")) {
           return false;
        }

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -160,11 +160,19 @@ $(document).ready(function() {
     });
 });
 
+// Update the category buttons
 $('.btnCatFilter').click(function(){
     var was_selected = $(this).hasClass('active');
     $('.btnCatFilter').removeClass('active');
     if(!was_selected){ $(this).addClass('active'); }
     });
+
+//Remove hover text from clicked button
+$(document).ready(function(){
+       $('[data-toggle="tooltip"]').click(function () {
+          $('[data-toggle="tooltip"]').tooltip("hide");
+       });
+})
 
 // Preview running notes
 $('#new_note_text').keyup(preview_running_notes);

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -8,25 +8,26 @@ $(function(){
 });
 
 function generate_category_label(category){
-    if (category == 'Workset'){
-         category='<span class="label label-primary">'+ category +"</span>";
-     }else if (category == 'Flowcell'){
-         category='<span class="label label-success">'+ category +"</span>";
-     }else if (category == 'Meeting' || category == "Decision"){
-         category='<span class="label label-info">'+ category +"</span>";
-     }else if (category == 'User Communication'){
-         category='<span class="label label-danger">'+ category +"</span>";
-     }else if (category == 'Bioinformatics'){
-         category='<span class="label label-warning">'+ category +"</span>";
-     }else if (category == 'Important'){
-         category='<span class="label label-imp">'+ category +"</span>";
-     }else if (category == 'Deviation'){
-	       category='<span class="label label-devi">'+ category +"</span>";
-     }else if (category != ''){
-         category='<span class="label label-default">'+ category +"</span>";
-     }
-     return category;
+   if (category == 'Decision'){
+        category='<span class="label label-info">'+ category +"</span>";
+    }else if (category == 'Lab'){
+        category='<span class="label label-success">'+ category +"</span>";
+    }else if (category == 'Bioinformatics'){
+        category='<span class="label label-warning">'+ category +"</span>";
+    }else if (category == 'User Communication'){
+        category='<span class="label label-usr">'+ category +"</span>";
+    }else if (category == 'Administration'){
+        category='<span class="label label-danger">'+ category +"</span>";
+    }else if (category == 'Important'){
+        category='<span class="label label-imp">'+ category +"</span>";
+    }else if (category == 'Deviation'){
+        category='<span class="label label-devi">'+ category +"</span>";
+    }else if (category != ''){
+        category='<span class="label label-default">'+ category +"</span>";
+    }
+    return category;
 }
+
 function get_note_url() {
     // URL for the notes
     if ((typeof notetype !== 'undefined' && notetype == 'lims_step') || ('lims_step' in window && lims_step !== null)){
@@ -117,7 +118,7 @@ function load_running_notes(wait) {
 function preview_running_notes(){
     var now = new Date();
     $('.todays_date').text(now.toDateString() + ', ' + now.toLocaleTimeString());
-    var category = generate_category_label($('#rn_category option:selected').val());
+    var category = generate_category_label($('.btnCatFilter.active').val());
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
@@ -143,33 +144,46 @@ function filter_running_notes(search){
         }
     });
 }
-//Filter notes by Category
+//Filter notes
 $('#rn_search').keyup(function() {
     var search=$('#rn_search').val();
     filter_running_notes(search);
 });
-$('.btnCatFilter').click(function() {
-    $('.btnCatFilter').each(function() {$(this).removeClass("glow")});
-    $(this).addClass("glow")
-    var search=$(this).text();
-    if (search == 'All'){
-        search='';
-    }
-    filter_running_notes(search);
+
+$(document).ready(function() {
+    $('#rn_category').change(function() {
+        var search=$('#rn_category :selected').text();
+        if (search == 'All'){
+            search='';
+        }
+        filter_running_notes(search);
+    });
 });
+
+$('.btnCatFilter').click(function(){
+    var was_selected = $(this).hasClass('active');
+    $('.btnCatFilter').removeClass('active');
+    if(!was_selected){ $(this).addClass('active'); }
+    });
+
 // Preview running notes
 $('#new_note_text').keyup(preview_running_notes);
-$('#rn_category').change(preview_running_notes);
+$('.btnCatFilter').change(preview_running_notes);
 
 // Insert new running note and reload the running notes table
 $("#running_notes_form").submit( function(e) {
     e.preventDefault();
     var text = $('#new_note_text').val().trim();
     text = $('<div>').text(text).html();
-    var category = $('#rn_category option:selected').val();
+    var category = $('.btnCatFilter.active').val();
     if (text.length == 0) {
         alert("Error: No running note entered.");
         return false;
+    }
+    if (!$('.btnCatFilter.active').val()) {
+       if (!confirm("Are you sure that you want to submit without choosing a category?")) {
+          return false;
+       }
     }
 
     note_url = get_note_url()

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -168,7 +168,7 @@ $('.btnCatFilter').click(function(){
 
 // Preview running notes
 $('#new_note_text').keyup(preview_running_notes);
-$('.btnCatFilter').change(preview_running_notes);
+$('.btnCatFilter').click(preview_running_notes);
 
 // Insert new running note and reload the running notes table
 $("#running_notes_form").submit( function(e) {


### PR DESCRIPTION
- Removed the “meeting” category, 
- Renamed “invoicing” to “administration”, 
- Added new category "lab", 
- Added a warning message when one attempts to create a running note without first having chosen a category, 
- Added an explaining text to each category on when to use it on hover, 
- Turned category selection dropdown into buttons and the filter buttons into a dropdown.

So currently you have to select a category first, then write the note, and then the preview updates.
If you want to change category you have to click the button again, choose another button, and re-write the note or the preview won’t update. 

I'm not sure if this can be changed in a smooth way, maybe you guys have more insight into how this could be done, Anand and Johannes? :-)

I'll add this on stage so you can play with it!

