### PR TITLE
Added new field 'connected projects'

### DIFF
--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -147,6 +147,7 @@ Description: Details page for a single project
               <tr><td>E-mails</td><td id="contact"></td></tr>
               <tr><td>Affiliation</td><td id="affiliation"></td></tr>
               <tr><td>Invoice Reference</td><td><code id="invoice_reference"></code></td></tr>
+              <tr><td>Connected Projects</td><td id="connected_projects"></td></tr>
             </tbody>
           </table>
         </div>

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -475,9 +475,9 @@ function load_all_udfs(){
         conn_proj.forEach(function(proj){
            if (proj != project){
               if (!projs.trim()){
-                 projs += '<span class="email_link"><a href="/project/'+proj+'">'+proj+'</a>'+'</span>';
+                 projs += '<a class="email_link" href="/project/'+proj+'">'+proj+'</a>';
               }else{
-                 projs += ','+'&nbsp;'+'<span class="email_link"><a href="/project/'+proj+'">'+proj+'</a>'+'</span>';
+                 projs += ', '+'<a class="email_link" href="/project/'+proj+'">'+proj+'</a>';
               }
            }
         });

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -468,6 +468,21 @@ function load_all_udfs(){
         $('#textarea_internal_costs').html(value);
       }
 
+      //Add connected projects if any
+      else if (key == 'project_xref'){
+        projs = '';
+        var conn_proj = value.split(',');
+        conn_proj.forEach(function(proj){
+           if (proj != project){
+              if (!projs.trim()){
+                 projs += '<span class="email_link"><a href="/project/'+proj+'">'+proj+'</a>'+'</span>';
+              }else{
+                 projs += ','+'&nbsp;'+'<span class="email_link"><a href="/project/'+proj+'">'+proj+'</a>'+'</span>';
+              }
+           }
+        });
+        $('#connected_projects').html(projs);
+      }
 
       // Create the links for review and display the banner
       else if (prettify(key) == 'pending_reviews'){


### PR DESCRIPTION
Mattias and Pär asked for a new field in the project page for projects connected to one another. 
The udf doesn't exist for all projects, only for those with connected projects, so the field will be empty for most projects. 

It's on stage, some examples are projects P9020, P7454, and P11807.