### PR TITLE
Write running note to projects from FC only after the save to LIMS

### DIFF
--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -352,15 +352,16 @@ class FlowcellNotesDataHandler(SafeHandler):
                 flowcell_link = "<a href='/flowcells/{0}'>{0}</a>".format(flowcell)
                 project_note = "#####*Running note posted on flowcell {}:*\n".format(flowcell_link)
                 project_note += note
+
+                p.udf['Notes'] = json.dumps(running_notes)
+                p.put()
+                #write running note to projects only if it has been saved successfully in FC
                 for project in projects:
                     RunningNotesDataHandler.make_project_running_note(
                         self.application, project,
                         project_note, category,
                         user.name, user.email
                     )
-
-                p.udf['Notes'] = json.dumps(running_notes)
-                p.put()
                 self.set_status(201)
                 self.write(json.dumps(newNote))
 


### PR DESCRIPTION
Running note failed to be saved to LIMS for 201127_BHGNHJDSXY and was retried manually multiple times. Eventhough the note was saved to the FC only in the last successful attempt, it was written to to the project P15502 for every attempt.