### PR TITLE
Removed extra delivery categories from data delivered plot

### DIFF
--- a/run_dir/static/js/data_del_plot.js
+++ b/run_dir/static/js/data_del_plot.js
@@ -178,6 +178,10 @@ function build_series(data, key, name, view_type, filter_inst_type){
         }else if (view_type == 'delivery_type'){
             if (data[d][1].delivery_type == null){
                 series_name = "Other/undefined";
+            }else if (data[d][1].delivery_type == "HDD with raw data"){
+                series_name = "HDD";
+            }else if (data[d][1].delivery_type == "GRUS with raw data"){
+                series_name = "GRUS";
             }else{
                 series_name = data[d][1].delivery_type;
             }


### PR DESCRIPTION
Since we have added the two new delivery options, "HDD with raw data" and "GRUS with raw data" we have four categories in the plot under "Delivery." 
So I added the corresponding category to the two already existing ones.