### PR TITLE
Added multiple running note selection, and delivery category "in-house" to deliveries plot page

### DIFF
--- a/run_dir/static/js/data_del_plot.js
+++ b/run_dir/static/js/data_del_plot.js
@@ -182,6 +182,8 @@ function build_series(data, key, name, view_type, filter_inst_type){
                 series_name = "HDD";
             }else if (data[d][1].delivery_type == "GRUS with raw data"){
                 series_name = "GRUS";
+            }else if (data[d][1].delivery_type == "In-house"){
+                series_name = "In-house";
             }else{
                 series_name = data[d][1].delivery_type;
             }
@@ -260,6 +262,7 @@ function view_coloring(series_name){
         case "Application":
         case "total RNA":
         case "No BP bioinformatics":
+        case "In-house":
             return chroma('blue').hex();
         case "NextSeq":
         case "GRUS":

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -21,13 +21,29 @@ function generate_category_label(category){
         'Invoicing': ['inv', 'file-invoice-dollar']
     }
     // Remove the whitespace
-    var category = category.trim()
-    // Check if we recognise this category in the class object keys
-    if (Object.keys(cat_classes).indexOf(category) != -1){
-        cat_label = '<span class="badge bg-'+ cat_classes[category][0] +'">'+ category + '&nbsp;' + '<span class="fa fa-'+ cat_classes[category][1] +'">'+"</span></span>";
-    }else{
-    // Default button formatting
-        cat_label = '<span class="badge bg-secondary">'+ category +"</span>";
+    var categories = category.trim()
+    //Below can probably be simplified
+    var cat_label = '';
+    if (categories.includes('Workset')){
+      cat_label += '<span class="badge bg-'+cat_classes['Workset'][0]+'">'+'Workset '+'<span class="fa fa-'+cat_classes['Workset'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Flowcell')){
+      cat_label += '<span class="badge bg-'+cat_classes['Flowcell'][0]+'">'+'Flowcell '+'<span class="fa fa-'+cat_classes['Flowcell'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Decision')){
+      cat_label += '<span class="badge bg-'+cat_classes['Decision'][0]+'">'+'Decision '+'<span class="fa fa-'+cat_classes['Decision'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Lab')){
+      cat_label += '<span class="badge bg-'+cat_classes['Lab'][0]+'">'+'Lab '+'<span class="fa fa-'+cat_classes['Lab'][1]+'">'+'</span></span> '; 
+    }if (categories.includes('Bioinformatics')){
+      cat_label += '<span class="badge bg-'+cat_classes['Bioinformatics'][0]+'">'+'Bioinformatics '+'<span class="fa fa-'+cat_classes['Bioinformatics'][1]+'">'+'</span></span> ';
+    }if (categories.includes('User') && categories.includes('Communication')){
+      cat_label += '<span class="badge bg-'+cat_classes['User Communication'][0]+'">'+'User Communication '+'<span class="fa fa-'+cat_classes['User Communication'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Administration')){
+      cat_label += '<span class="badge bg-'+cat_classes['Administration'][0]+'">'+'Administration '+'<span class="fa fa-'+cat_classes['Administration'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Important')){
+      cat_label += '<span class="badge bg-'+cat_classes['Important'][0]+'">'+'Important '+'<span class="fa fa-'+cat_classes['Important'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Deviation')){
+      cat_label += '<span class="badge bg-'+cat_classes['Deviation'][0]+'">'+'Deviation '+'<span class="fa fa-'+cat_classes['Deviation'][1]+'">'+'</span></span> ';
+    }if (categories.includes('Invoicing')){
+      cat_label += '<span class="badge bg-'+cat_classes['Invoicing'][0]+'">'+'Invoicing '+'<span class="fa fa-'+cat_classes['Invoicing'][1]+'">'+'</span></span> ';
     }
     return cat_label;
 }
@@ -127,6 +143,7 @@ function preview_running_notes(){
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
+    text = $('<div>').text(text).html();
     if (text.length > 0) {
         $('#running_note_preview_body').html(make_markdown(text));
         check_img_sources($('#running_note_preview_body img'));
@@ -199,7 +216,9 @@ $('#rn_category ~ ul > li > button').on('click', function(){
 $('.rn-categ button').click(function(e){
     e.preventDefault();
     var was_selected = $(this).hasClass('active');
-    $('.rn-categ button').removeClass('active');
+    if(was_selected){
+        $(this).removeClass('active');
+    }
     if(!was_selected){
         $(this).addClass('active');
     }

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -126,7 +126,7 @@ function preview_running_notes(){
     $('.rn-categ button.active').each(function() {
       categories.push($(this).text());
     });
-    var category = generate_category_label(categories);
+    var category = generate_category_label(categories.join());
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -143,7 +143,6 @@ function preview_running_notes(){
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
-    text = $('<div>').text(text).html();
     if (text.length > 0) {
         $('#running_note_preview_body').html(make_markdown(text));
         check_img_sources($('#running_note_preview_body img'));

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -20,31 +20,21 @@ function generate_category_label(category){
         'Deviation': ['devi', 'frown'],
         'Invoicing': ['inv', 'file-invoice-dollar']
     }
+    var cat_label = '';
     // Remove the whitespace
     var categories = category.trim()
-    //Below can probably be simplified
-    var cat_label = '';
-    if (categories.includes('Workset')){
-      cat_label += '<span class="badge bg-'+cat_classes['Workset'][0]+'">'+'Workset '+'<span class="fa fa-'+cat_classes['Workset'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Flowcell')){
-      cat_label += '<span class="badge bg-'+cat_classes['Flowcell'][0]+'">'+'Flowcell '+'<span class="fa fa-'+cat_classes['Flowcell'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Decision')){
-      cat_label += '<span class="badge bg-'+cat_classes['Decision'][0]+'">'+'Decision '+'<span class="fa fa-'+cat_classes['Decision'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Lab')){
-      cat_label += '<span class="badge bg-'+cat_classes['Lab'][0]+'">'+'Lab '+'<span class="fa fa-'+cat_classes['Lab'][1]+'">'+'</span></span> '; 
-    }if (categories.includes('Bioinformatics')){
-      cat_label += '<span class="badge bg-'+cat_classes['Bioinformatics'][0]+'">'+'Bioinformatics '+'<span class="fa fa-'+cat_classes['Bioinformatics'][1]+'">'+'</span></span> ';
-    }if (categories.includes('User') && categories.includes('Communication')){
-      cat_label += '<span class="badge bg-'+cat_classes['User Communication'][0]+'">'+'User Communication '+'<span class="fa fa-'+cat_classes['User Communication'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Administration')){
-      cat_label += '<span class="badge bg-'+cat_classes['Administration'][0]+'">'+'Administration '+'<span class="fa fa-'+cat_classes['Administration'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Important')){
-      cat_label += '<span class="badge bg-'+cat_classes['Important'][0]+'">'+'Important '+'<span class="fa fa-'+cat_classes['Important'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Deviation')){
-      cat_label += '<span class="badge bg-'+cat_classes['Deviation'][0]+'">'+'Deviation '+'<span class="fa fa-'+cat_classes['Deviation'][1]+'">'+'</span></span> ';
-    }if (categories.includes('Invoicing')){
-      cat_label += '<span class="badge bg-'+cat_classes['Invoicing'][0]+'">'+'Invoicing '+'<span class="fa fa-'+cat_classes['Invoicing'][1]+'">'+'</span></span> ';
-    }
+    var cat = categories.split(' ')
+    Object.values(cat).forEach(function(val){
+      if (cat.indexOf('User') != -1) { 
+        cat.splice(cat.indexOf('User'), 1);
+      }
+      if (val == 'Communication'){
+        val = 'User Communication';
+      }
+      if (Object.keys(cat_classes).indexOf(val) != -1){
+          cat_label += '<span class="badge bg-'+cat_classes[val][0]+'">'+val+'&nbsp;'+'<span class="fa fa-'+ cat_classes[val][1] +'">'+"</span></span> ";
+      }
+    });
     return cat_label;
 }
 

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -124,7 +124,7 @@ function preview_running_notes(){
     $('.todays_date').text(now.toDateString() + ', ' + now.toLocaleTimeString());
     var categories = []
     $('.rn-categ button.active').each(function() {
-      categories.push($(this).text());
+      categories.push($(this).text().trim());
     });
     var category = generate_category_label(categories.join());
     category = category ? ' - '+ category : category;
@@ -205,7 +205,7 @@ $('.rn-categ button').click(function(e){
     if(was_selected){
         $(this).removeClass('active');
     }
-    if(!was_selected){
+    else{
         $(this).addClass('active');
     }
     preview_running_notes();

--- a/run_dir/static/js/running_notes.js
+++ b/run_dir/static/js/running_notes.js
@@ -21,18 +21,11 @@ function generate_category_label(category){
         'Invoicing': ['inv', 'file-invoice-dollar']
     }
     var cat_label = '';
-    // Remove the whitespace
-    var categories = category.trim()
-    var cat = categories.split(' ')
-    Object.values(cat).forEach(function(val){
-      if (cat.indexOf('User') != -1) { 
-        cat.splice(cat.indexOf('User'), 1);
-      }
-      if (val == 'Communication'){
-        val = 'User Communication';
-      }
-      if (Object.keys(cat_classes).indexOf(val) != -1){
-          cat_label += '<span class="badge bg-'+cat_classes[val][0]+'">'+val+'&nbsp;'+'<span class="fa fa-'+ cat_classes[val][1] +'">'+"</span></span> ";
+    var categories = category.split(',')
+    Object.values(categories).forEach(function(val){
+      var cat = val.trim()
+      if (Object.keys(cat_classes).indexOf(cat) != -1){
+          cat_label += '<span class="badge bg-'+cat_classes[cat][0]+'">'+cat+'&nbsp;'+'<span class="fa fa-'+ cat_classes[cat][1] +'">'+"</span></span> ";
       }
     });
     return cat_label;
@@ -85,7 +78,7 @@ function make_running_note(date, note){
   }
   var printHyphen =category? ' - ': ' ';
   var panelClass='';
-  if (note['category'] == 'Important') {
+  if (note['category'].includes('Important')) {
     panelClass = 'card-important';
   }
   return '<div class="card mb-2 mx-2">' +
@@ -129,7 +122,11 @@ function load_running_notes(wait) {
 function preview_running_notes(){
     var now = new Date();
     $('.todays_date').text(now.toDateString() + ', ' + now.toLocaleTimeString());
-    var category = generate_category_label($('.rn-categ button.active').text());
+    var categories = []
+    $('.rn-categ button.active').each(function() {
+      categories.push($(this).text());
+    });
+    var category = generate_category_label(categories);
     category = category ? ' - '+ category : category;
     $('#preview_category').html(category);
     var text = $('#new_note_text').val().trim();
@@ -229,7 +226,11 @@ $("#running_notes_form").submit( function(e) {
     e.preventDefault();
     var text = $('#new_note_text').val().trim();
     text = $('<div>').text(text).html();
-    var category = $('.rn-categ button.active').text();
+    var categories = [];
+    $('.rn-categ button.active').each(function() {
+      categories.push($(this).text().trim());
+    });
+    category = categories.join()
     if (text.length == 0) {
         alert("Error: No running note entered.");
         return false;


### PR DESCRIPTION
The running note category formatting can probably be simplified/cleaned up, but I don't know how right now.

As I said in the meeting, I can't save running notes from testing user, so I can't see if the labels are added/saved to the actual notes, just to the preview 🤷‍♀️ 

