### PR TITLE
Remove internal dashboard button

### DIFF
--- a/run_dir/design/index.html
+++ b/run_dir/design/index.html
@@ -30,12 +30,6 @@
 	</div>
 	<div class="col-lg-2 col-sm-4 col-xs-6">
 		<div class="well">
-			  <h3><a href="https://ngi-dashboards.scilifelab.se/dbi/"><i class="fa fa-tachometer"></i></a></h3>
-			<p><a class="btn btn-primary btn-lg"  href="https://ngi-dashboards.scilifelab.se/dbi/">Internal Dashboard</a></p>
-		</div>
-	</div>
-	<div class="col-lg-2 col-sm-4 col-xs-6">
-		<div class="well">
 			  <h3><a href="https://ngi-dashboards.scilifelab.se/dbe/"><i class="fa fa-globe-europe"></i></a></h3>
 			<p><a class="btn btn-primary btn-lg"  href="https://ngi-dashboards.scilifelab.se/dbe/">External Dashboard</a></p>
 		</div>


### PR DESCRIPTION
I'm in the process of nuking the internal dashboard. This link on the frontpage too.

I know it looks a little bit weird this way, but we should think about what buttons go here ( or if we should remove these buttons? Do any one use them? ) 

<img width="1438" alt="Screenshot 2022-02-24 at 13 13 34" src="https://user-images.githubusercontent.com/6576325/155522792-29f50e3a-d1dd-4287-b4b8-c7fefd1c0150.png">

Anyway a small change.