### PR TITLE
Display cost with additional costs and discount added instead

### DIFF
--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -491,7 +491,7 @@ app.component('v-pricing-quote', {
                             (Internal projects)
                             </template>
                           </div>
-                          <p class="text-right col-3 pt-2 fw-bold pr-0">{{product_cost_sum[this.$root.price_type].toFixed(2)}} SEK</p>
+                          <p class="text-right col-3 pt-2 fw-bold pr-0">{{quote_cost[this.$root.price_type]}} SEK </p>
                         </li>
                       </ul>
 


### PR DESCRIPTION
Only the Product cost without the additional costs and discount added was shown before.