### PR TITLE
Uncheck failed samples by default on lane level in the reads aggregation-page

### DIFF
--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -66,8 +66,8 @@ Description: Summing tool for the reads
                         {% if '_UD' not in d['fcp']  %}
                             {% if d['q30'] is not None and d['q30']>75 %}
                                 <td class="table-success myq30">{{ d['q30'] }}</td>
-                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d['sample_status'] != 'Failed' %} checked {% end %} /></td>   
-                            {% elif d['q30'] is not None and d['q30']>30  %}
+                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d['sample_status'] != 'Failed' %} checked {% end %} /></td>
+                            {% elif d['q30'] is not None and d['q30']>30 %}
                                 <td class="table-warning myq30">{{ d['q30'] }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                             {% else %}

--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -66,8 +66,12 @@ Description: Summing tool for the reads
                         {% if '_UD' not in d['fcp']  %}
                             {% if d['q30'] is not None and d['q30']>75 %}
                                 <td class="table-success myq30">{{ d['q30'] }}</td>
-                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" checked /></td>
-                            {% elif d['q30'] is not None and d['q30']>30 %}
+                                {% if d['sample_status'] != 'Failed' %}
+                                    <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" checked/></td>
+                                {% else %}
+                                    <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" /></td>
+                                {% end %}
+                            {% elif d['q30'] is not None and d['q30']>30  %}
                                 <td class="table-warning myq30">{{ d['q30'] }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                             {% else %}

--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -66,11 +66,7 @@ Description: Summing tool for the reads
                         {% if '_UD' not in d['fcp']  %}
                             {% if d['q30'] is not None and d['q30']>75 %}
                                 <td class="table-success myq30">{{ d['q30'] }}</td>
-                                {% if d['sample_status'] != 'Failed' %}
-                                    <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" checked/></td>
-                                {% else %}
-                                    <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" /></td>
-                                {% end %}
+                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d['sample_status'] != 'Failed' %} checked {% end %} /></td>   
                             {% elif d['q30'] is not None and d['q30']>30  %}
                                 <td class="table-warning myq30">{{ d['q30'] }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -422,13 +422,11 @@ class ReadsTotalHandler(SafeHandler):
                     data[row.key]=[]
                 data[row.key].append(row.value)
             #To check if sample is failed on lane level
-            for row in bioinfo_view:
-                if row.key[3] in data:
-                    for k,v in data.items():
-                        if k == row.key[3]:
-                            for fcl in v:
-                                if row.key[1] + ':' + row.key[2] == fcl['fcp']:
-                                    fcl['sample_status'] = row.value['sample_status']
+            for row in bioinfo_view[[query, None, None, None]:[f'{query}Z', 'ZZ', 'ZZ', 'ZZ']]:
+                    if row.key[3] in data:
+                        for fcl in data[row.key[3]]:
+                            if row.key[1] + ':' + row.key[2] == fcl['fcp']:
+                                fcl['sample_status'] = row.value['sample_status']
             for key in sorted(data.keys()):
                 ordereddata[key]=sorted(data[key], key=lambda d:d['fcp'])
             self.write(t.generate(gs_globals=self.application.gs_globals, user=self.get_current_user(), readsdata=ordereddata, query=query))

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -427,6 +427,7 @@ class ReadsTotalHandler(SafeHandler):
                         for fcl in data[row.key[3]]:
                             if row.key[1] + ':' + row.key[2] == fcl['fcp']:
                                 fcl['sample_status'] = row.value['sample_status']
+                                break # since the row is already found
             for key in sorted(data.keys()):
                 ordereddata[key]=sorted(data[key], key=lambda d:d['fcp'])
             self.write(t.generate(gs_globals=self.application.gs_globals, user=self.get_current_user(), readsdata=ordereddata, query=query))

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -416,10 +416,19 @@ class ReadsTotalHandler(SafeHandler):
             self.write(t.generate(gs_globals=self.application.gs_globals, user=self.get_current_user(), readsdata=ordereddata, query=query))
         else:
             xfc_view = self.application.x_flowcells_db.view("samples/lane_clusters", reduce=False)
+            bioinfo_view = self.application.bioinfo_db.view("latest_data/sample_id")
             for row in xfc_view[query:"{}Z".format(query)]:
                 if not row.key in data:
                     data[row.key]=[]
                 data[row.key].append(row.value)
+            #To check if sample is failed on lane level
+            for row in bioinfo_view:
+                if row.key[3] in data:
+                    for k,v in data.items():
+                        if k == row.key[3]:
+                            for fcl in v:
+                                if row.key[1] + ':' + row.key[2] == fcl['fcp']:
+                                    fcl['sample_status'] = row.value['sample_status']
             for key in sorted(data.keys()):
                 ordereddata[key]=sorted(data[key], key=lambda d:d['fcp'])
             self.write(t.generate(gs_globals=self.application.gs_globals, user=self.get_current_user(), readsdata=ordereddata, query=query))


### PR DESCRIPTION
This was requested by Pär two and a half years ago 😆 

See, e.g., P15502, 200428_A00187_0298_AH5YKGDSXY, lane 1, sample P15502_201.

The looping might be a bit too heavy? But I can't seem to figure out how to use less looping and get the same result.

I don't know if a new view would help that much?