### PR TITLE
HOTFIX: Copy sample table

### DIFF
--- a/run_dir/static/css/status_b5.css
+++ b/run_dir/static/css/status_b5.css
@@ -257,6 +257,14 @@ tr.group, tr.group:hover, .dtrg-group {
 
 /*Line numbers for samples tab table*/
 
+#sample_table thead tr::before {
+  content: "No:";
+  background-color: #ddd!important;
+  display: table-cell;
+  font-weight: bold;
+  padding: 0.5rem 0.5rem;
+} 
+
 #sample_table tbody {
   counter-reset: row;
 }

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -26,7 +26,6 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
-
   // Copy project samples table to clipboard
   var clipboard = new Clipboard('#proj_samples_copy_table');
   clipboard.on('success', function(e) {

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -26,6 +26,7 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
+
   // Copy project samples table to clipboard
   var clipboard = new Clipboard('#proj_samples_copy_table');
   clipboard.on('success', function(e) {
@@ -604,7 +605,7 @@ function safeobj(s) {
 
 
 function load_table_head(columns){
-  var tbl_head = '<tr class="sticky darkth"><th>No:</th>';
+  var tbl_head = '<tr class="sticky darkth">';
   $.each(columns, function(i, column_tuple) {
     tbl_head += '<th class="sort a" data-sort="' + column_tuple[1] + '">';
 


### PR DESCRIPTION
When you copy the samples table, it doesn't copy the line numbers (as these are pseudo-elements), so the table gets shifted, as discovered by Orlando.
By making the header a pseudo-element as well, it won't be copied.