### PR TITLE
Fix calc crash for barcode runs w/o reads

### DIFF
--- a/status/flowcell.py
+++ b/status/flowcell.py
@@ -278,11 +278,10 @@ class ONTFlowcellHandler(SafeHandler):
             df.loc[df.bc_name == df.barcode_alias, "barcode_alias"] = ""
 
             # Calculate percentages
-            if sum(df.basecalled_pass_read_count) > 0:
-                df["basecalled_pass_read_count_pc"] = round(df.basecalled_pass_read_count / sum(df.basecalled_pass_read_count) * 100, 2)
-
-            if sum(df.basecalled_pass_bases) > 0:
-                df["basecalled_pass_bases_pc"] = round(df.basecalled_pass_bases / sum(df.basecalled_pass_bases) * 100, 2)
+            df["basecalled_pass_read_count_pc"] = round(df.basecalled_pass_read_count / sum(df.basecalled_pass_read_count) * 100, 2) \
+                if sum(df.basecalled_pass_read_count) > 0 else "-"
+            df["basecalled_pass_bases_pc"] = round(df.basecalled_pass_bases / sum(df.basecalled_pass_bases) * 100, 2) \
+                if sum(df.basecalled_pass_bases) > 0 else "-"
 
             df["average_read_length_passed"] = df.apply(
                 lambda x: \


### PR DESCRIPTION
Discovered that ONT run [20220721_1225_2G_PAM62325_a47cdd15](https://genomics-status.scilifelab.se/flowcells/20220721_1225_2G_PAM62325_a47cdd15) could not be shown. Troubleshooting found that this was due to the barcode calculations not being properly built to handle barcodes without any reads.

Implemented fix and tested locally.