### PR TITLE
Enable automatic rendering of Highcharts plot on project select change

### DIFF
--- a/run_dir/static/js/proj_meta_compare.js
+++ b/run_dir/static/js/proj_meta_compare.js
@@ -23,6 +23,7 @@
     project_data = {};
     var id_tosave = [];
     var sel = '';
+    count = 0;
     key_min = {'base': {}, 'library_prep': {}, 'rna_meta' :{}};
     key_max = {'base': {}, 'library_prep': {}, 'rna_meta' :{}};
     xLogAxis = 'linear';
@@ -51,6 +52,7 @@
             empty: '<div class="empty-message">No projects found</div>'
         }
         }).bind('typeahead:selected', function(obj, datum, name) {
+            count++;
             let proj_id = datum.url.split('/')[2];
             $('#projects_meta_input').val('');
             $('#del_pid_badges').append('<button class="btn badge rounded-pill bg-secondary mx-1" id="' + proj_id +  '">' + proj_id + '<i class="fa fa-solid fa-xmark ml-2"></i>' + '</button>');
@@ -161,11 +163,7 @@
         if($('#proj_meta_plot').highcharts()) {
             $('#proj_meta_plot').highcharts().destroy();
         }
-        $('#proj_meta_plot').html('<p class="text-center text-muted">Please select an X and a Y variable.</p>');
-        $('#proj_meta_correlation').text('?');
-        $('#projMeta_downloadAll, #projMeta_copyRaw').prop('disabled', true);
-        $('#proj_meta_yvalue, #proj_meta_xvalue').prop('disabled', true).html('<option value="">[ select value ]</option>');
-        $('#proj_meta_colvalue').prop('disabled', true).html('<option data-section="" value="">Project</option>');
+
 
         // Clean up the user input
         var projects = [];
@@ -313,7 +311,14 @@
                     }
                     group.appendTo($('#proj_meta_yvalue, #proj_meta_xvalue, #proj_meta_colvalue'));
                 }
-
+                //If this is not the default plot
+                if (count > 0){
+                    plot_meta({'y': [$('#proj_meta_yvalue option:selected').data('section'),
+                        $('#proj_meta_yvalue').val()], 'x': [$('#proj_meta_xvalue option:selected').data('section'),
+                        $('#proj_meta_xvalue').val()],'color': [$('#proj_meta_colvalue option:selected').data('section'),
+                        $('#proj_meta_colvalue').val()]
+                    })
+                }
                 // Remove disabled states
                 $('#proj_meta_yvalue, #proj_meta_xvalue, #proj_meta_colvalue, #projMeta_downloadAll, #projMeta_copyRaw').prop('disabled', false);
 

--- a/run_dir/static/js/proj_meta_compare.js
+++ b/run_dir/static/js/proj_meta_compare.js
@@ -139,6 +139,13 @@
             });
             load_projects_meta(id_tosave);
             but_id.remove();
+            if (count == 0){
+                plot_meta({'y': [$('#proj_meta_yvalue option:selected').data('section'),
+                        $('#proj_meta_yvalue').val()], 'x': [$('#proj_meta_xvalue option:selected').data('section'),
+                        $('#proj_meta_xvalue').val()],'color': [$('#proj_meta_colvalue option:selected').data('section'),
+                        $('#proj_meta_colvalue').val()]
+                })
+            }
         });
     }
 

--- a/run_dir/static/js/proj_meta_compare.js
+++ b/run_dir/static/js/proj_meta_compare.js
@@ -140,11 +140,7 @@
             load_projects_meta(id_tosave);
             but_id.remove();
             if (count == 0){
-                plot_meta({'y': [$('#proj_meta_yvalue option:selected').data('section'),
-                        $('#proj_meta_yvalue').val()], 'x': [$('#proj_meta_xvalue option:selected').data('section'),
-                        $('#proj_meta_xvalue').val()],'color': [$('#proj_meta_colvalue option:selected').data('section'),
-                        $('#proj_meta_colvalue').val()]
-                })
+                pre_plot_meta();
             }
         });
     }
@@ -160,6 +156,7 @@
         $('#proj_meta_xvalue, #proj_meta_yvalue, #proj_meta_colvalue').val('customer_conc').trigger('click');
         plot_meta({'y': ['base', 'customer_conc'], 'x': ['base', 'customer_conc'],'color': ['base', 'customer_conc']})
     }
+
 
     // Main function that fires when project IDs are filled in and the form
     // is submitted. Loads page.
@@ -319,11 +316,7 @@
                 }
                 //If this is not the default plot
                 if (count > 0){
-                    plot_meta({'y': [$('#proj_meta_yvalue option:selected').data('section'),
-                        $('#proj_meta_yvalue').val()], 'x': [$('#proj_meta_xvalue option:selected').data('section'),
-                        $('#proj_meta_xvalue').val()],'color': [$('#proj_meta_colvalue option:selected').data('section'),
-                        $('#proj_meta_colvalue').val()]
-                    })
+                    pre_plot_meta();
                 }
                 // Remove disabled states
                 $('#proj_meta_yvalue, #proj_meta_xvalue, #proj_meta_colvalue, #projMeta_downloadAll, #projMeta_copyRaw').prop('disabled', false);
@@ -332,7 +325,13 @@
         });
     }
 
-
+    function pre_plot_meta() {
+        plot_meta({'y': [$('#proj_meta_yvalue option:selected').data('section'),
+                        $('#proj_meta_yvalue').val()], 'x': [$('#proj_meta_xvalue option:selected').data('section'),
+                        $('#proj_meta_xvalue').val()],'color': [$('#proj_meta_colvalue option:selected').data('section'),
+                        $('#proj_meta_colvalue').val()]
+        })
+    }
 
     // Function to create new meta scatter plot.
     function plot_meta(keys){

--- a/run_dir/static/js/proj_meta_compare.js
+++ b/run_dir/static/js/proj_meta_compare.js
@@ -164,7 +164,6 @@
             $('#proj_meta_plot').highcharts().destroy();
         }
 
-
         // Clean up the user input
         var projects = [];
         for (var i = 0; i < id_tosave.length; i++) {


### PR DESCRIPTION
The `count` variable is used to get rid of the `No data found to plot. Please try another combination.`- one-second-flickering on page load.

It should work now!

Requested by Johannes with _"Do not reset plot settings when adding a new project"_ in https://trello.com/c/CW0KOcCU/1511-overhaul-of-compare-project-meta-on-genstat.