### PR TITLE
Update DataTables to v 1.13.6 for flowcells page and add copy buttons extension

### DIFF
--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -232,6 +232,7 @@ Description: Shows a table with all flow cells.
 </div>
 
 <script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 
 <!-- Table Sorting -->
 <script type="text/javascript">
@@ -254,7 +255,12 @@ function init_listjs() {
     var table = $('#fc_table').DataTable({
       "paging":false,
       "info":false,
-      "order": [[ 1, "desc" ]]
+      "order": [[ 1, "desc" ]],
+      dom: 'Bfrti',
+      buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ]
     });
 
     //Add the bootstrap classes to the search thingy
@@ -275,6 +281,8 @@ function init_listjs() {
             .draw();
         } );
     } );
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 }
 </script>
 

--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -231,7 +231,6 @@ Description: Shows a table with all flow cells.
     </div>
 </div>
 
-<script src="/static/js/jquery.dataTables.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 
 <!-- Table Sorting -->

--- a/run_dir/design/ont_flowcells.html
+++ b/run_dir/design/ont_flowcells.html
@@ -243,7 +243,12 @@ function init_listjs_ont() {
         "paging":false,
         "info":false,
         "order": [[ 0, "desc" ]],
-        "autoWidth":true
+        "autoWidth":true,
+        dom: 'Bfrti',
+        buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ]
     });
 
     //Add the bootstrap classes to the search thingy


### PR DESCRIPTION
Mattias requested a copy button for the flowcells page here: https://trello.com/c/sHymyqg3/1591-there-is-no-copy-table-option-for-flowcell-list-in-genstat

We might as well implement the new buttons while we're at it, right? :-) 

I only added the buttons for the Illumina FCs, not the ONT, do you think we need for ONT also?