### PR TITLE
Updated DataTables to v 1.13.6 for a bunch of pages and Buttons ext. to seq qs

### DIFF
--- a/run_dir/design/agreements_tab.html
+++ b/run_dir/design/agreements_tab.html
@@ -5,7 +5,7 @@
   <!-- development version, includes helpful console warnings -->
   <script src="/static/js/vue.v3.2.47.global.prod.js"></script>
   <script src="/static/js/axios.v1.3.4.min.js"></script>
-  <script src="/static/js/jquery.dataTables.min.js"></script>
+  <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
   <script src="/static/js/marked.min.js"></script>
   <script src="/static/js/pricing_main.js?v={{ gs_globals['git_commit'] }}"></script>
   <script src="/static/js/pricing_quote.js?v={{ gs_globals['git_commit'] }}"></script>

--- a/run_dir/design/index.html
+++ b/run_dir/design/index.html
@@ -98,7 +98,7 @@
 
 <script src="https://code.highcharts.com/highcharts.js"></script>
 <script type="text/javascript" src="/static/js/index.js?v={{ gs_globals['git_commit'] }}" id="indexpage-js-import"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 
 {% end %}
 

--- a/run_dir/design/instrument_logs.html
+++ b/run_dir/design/instrument_logs.html
@@ -61,7 +61,7 @@ Description: Shows instrument logs for the given period.default is one week.
 </div>
 
 
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/bootstrap-datepicker.min.js"></script>
 <script src="/static/js/instrument_logs.js"></script>
 {% end %}

--- a/run_dir/design/invoicing.html
+++ b/run_dir/design/invoicing.html
@@ -97,7 +97,7 @@ Description: Shows a table with projects that have had invoice specs generated b
   </div>
 </div>
 
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/invoicing.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/libpooling_queues.html
+++ b/run_dir/design/libpooling_queues.html
@@ -42,8 +42,7 @@ Description: Shows a table with all Library pooling queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/libpooling_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/libpooling_queues.html
+++ b/run_dir/design/libpooling_queues.html
@@ -42,6 +42,7 @@ Description: Shows a table with all Library pooling queues.
     </div>
 </div>
 
+<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/libpooling_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/design/pricing_preview.html
+++ b/run_dir/design/pricing_preview.html
@@ -13,7 +13,7 @@
 <!-- development version, includes helpful console warnings -->
 <script src="/static/js/vue.v3.2.47.global.prod.js"></script>
 <script src="/static/js/axios.v1.3.4.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/pricing_main.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/pricing_preview.js?v={{ gs_globals['git_commit'] }}"></script>
 

--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -566,7 +566,7 @@ Description: Details page for a single project
 </div>
 
 <!-- Javascript -->
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/links.js?v={{ gs_globals['git_commit'] }}" id="ln-js" data-workset="{{ project }}"></script>
 <script src="/static/js/running_notes.js?v={{ gs_globals['git_commit'] }}" id="rn-js" data-project="{{project}}"></script>

--- a/run_dir/design/projects.html
+++ b/run_dir/design/projects.html
@@ -515,7 +515,7 @@ Description: Shows all presets configured for user and enables their selection.
 <script src="/static/js/jquery-ui.min.js"></script>
 <script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/bootstrap-datepicker.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/jQDateRangeSlider-min.js"></script>
 <script src="/static/js/projects.js?v={{ gs_globals['git_commit'] }}" id="projects-js"></script>
 {% end %}

--- a/run_dir/design/sample_requirements.html
+++ b/run_dir/design/sample_requirements.html
@@ -15,7 +15,7 @@
 <!-- development version, includes helpful console warnings -->
 <script src="/static/js/vue.v3.2.47.global.prod.js"></script>
 <script src="/static/js/axios.v1.3.4.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/sample_requirements.js?v={{ gs_globals['git_commit'] }}"></script>
 
 {% end %}

--- a/run_dir/design/sequencing_queues.html
+++ b/run_dir/design/sequencing_queues.html
@@ -59,6 +59,7 @@ Description: Shows a table with extant sequencing queues.
     </div>
 </div>
 
+<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/sequencing_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/design/sequencing_queues.html
+++ b/run_dir/design/sequencing_queues.html
@@ -14,7 +14,6 @@ Description: Shows a table with extant sequencing queues.
       <h1><span id="page_title">Sequencing queues</span>
         <small class="text-muted">Showing all sequencing queues</small>
       </h1>
-      <button type="button" id="seq_copy_table_btn" class="btn btn-outline-dark mb-2" data-clipboard-target="#queues_table"><span class="fa fa-copy"></span> Copy table</button>
       <table class="table table-hover table-striped table-bordered sortable" id="queues_table">
         <thead>
           <tr class="sticky darkth">
@@ -60,8 +59,7 @@ Description: Shows a table with extant sequencing queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/sequencing_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/sequencing_queues.html
+++ b/run_dir/design/sequencing_queues.html
@@ -59,7 +59,6 @@ Description: Shows a table with extant sequencing queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/sequencing_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/design/user_management.html
+++ b/run_dir/design/user_management.html
@@ -159,7 +159,7 @@ Description: Shows a table with all genomics-status users with options to modify
   </div>
 
   <script src="/static/js/user_management.js?v={{ gs_globals['git_commit'] }}" id="asrol-js" data-user='{{ user.email }}'></script>
-  <script src="/static/js/jquery.dataTables.min.js"></script>
+  <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
   <script src="/static/js/jquery-ui.min.js"></script>
 {% end %}
 </div>

--- a/run_dir/design/workset_queues.html
+++ b/run_dir/design/workset_queues.html
@@ -48,8 +48,7 @@ Description: Shows a table with extant workset queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/workset_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/workset_queues.html
+++ b/run_dir/design/workset_queues.html
@@ -48,6 +48,7 @@ Description: Shows a table with extant workset queues.
     </div>
 </div>
 
+<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/workset_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/static/js/sequencing_queues.js
+++ b/run_dir/static/js/sequencing_queues.js
@@ -76,6 +76,11 @@ function init_listjs() {
       "paging":false,
       "info":false,
       "order": [],
+      dom: 'Bfrti',
+      buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ],
       "drawCallback": function ( settings ) {
         var api = this.api();
         var rows = api.rows( {page:'current'} ).nodes();
@@ -136,13 +141,3 @@ function getDaysAndDateLabel(date, option){
   }
    return [number_of_days, label];
 }
-
-// Copy project samples table to clipboard
-var clipboard = new Clipboard('#seq_copy_table_btn');
-clipboard.on('success', function(e) {
-  e.clearSelection();
-  $('#seq_copy_table_btn').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-  setTimeout(function(){
-    $('#seq_copy_table_btn').removeClass('active').html('<span class="fa fa-copy"></span> Copy table');
-  }, 2000);
-});

--- a/run_dir/static/js/sequencing_queues.js
+++ b/run_dir/static/js/sequencing_queues.js
@@ -112,6 +112,9 @@ function init_listjs() {
             .draw();
         } );
     } );
+
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 }
 
 $('body').on('click', '.group', function(event) {


### PR DESCRIPTION
Updated:

- agreements_tab.html
- index.html
- instrument_logs.html
-  invoicing.html
- libpooling_queues.html
- pricing_preview.html
- project_samples.html
- projects.html
- sample_requirements.html
- sequencing_queues.html
- user_management.html
- workset_queues.html

I didn't add the Buttons extension to:

- libpooling_queues.html
- project_samples.html
- projects.html
- workset_queues.html

Since these copy buttons are a bit more complicated and you can't just replace them. It requires more work, so it's better to do it in another PR.