### PR TITLE
Updated DataTables to v 1.13.6 and added the buttons extension to some pages

### DIFF
--- a/run_dir/design/libpooling_queues.html
+++ b/run_dir/design/libpooling_queues.html
@@ -40,7 +40,6 @@ Description: Shows a table with all Library pooling queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/libpooling_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/design/libpooling_queues.html
+++ b/run_dir/design/libpooling_queues.html
@@ -14,7 +14,6 @@ Description: Shows a table with all Library pooling queues.
       <h1><span id="page_title">Library pooling queues</span>
         <small class="text-muted">Showing all Library pooling queues</small>
       </h1>
-      <button type="button" id="libpools_copy_table_btn" class="btn btn-outline-dark"><span class="fa fa-copy"></span> Copy table</button>
       <button type="button" id="libpools_copy_table" class="btn d-none" data-clipboard-target="#libpools_table"></button>
       <label class="btn btn-outline-dark expand-all float-right mb-2"><span class="fa fa-plus-square" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="libpools_table">
@@ -42,8 +41,7 @@ Description: Shows a table with all Library pooling queues.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/libpooling_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/libpooling_queues.html
+++ b/run_dir/design/libpooling_queues.html
@@ -14,7 +14,6 @@ Description: Shows a table with all Library pooling queues.
       <h1><span id="page_title">Library pooling queues</span>
         <small class="text-muted">Showing all Library pooling queues</small>
       </h1>
-      <button type="button" id="libpools_copy_table" class="btn d-none" data-clipboard-target="#libpools_table"></button>
       <label class="btn btn-outline-dark expand-all float-right mb-2"><span class="fa fa-plus-square" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="libpools_table">
         <thead>
@@ -42,6 +41,7 @@ Description: Shows a table with all Library pooling queues.
 </div>
 
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
+<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/libpooling_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/project_samples.html
+++ b/run_dir/design/project_samples.html
@@ -302,10 +302,6 @@ Description: Details page for a single project
         <div class="form-group col-12 p-2">
           <div id="search_field"></div>
         </div>
-        &nbsp;
-        <div class="form-group col-12 p-2 d-inline-flex">
-        <button type="button" id="proj_samples_copy_table" class="btn btn-sm btn-outline-secondary" data-clipboard-target="#sample_table"><span class="fa fa-copy"></span> Copy table</button>
-        </div>
         <div class="btn-toolbar p-2" role="toolbar">
           <label class="col-form-label p-1">Column Presets:</label>
           <div class="btn-group btn-group-sm" id="default_preset_buttons">
@@ -566,7 +562,7 @@ Description: Details page for a single project
 </div>
 
 <!-- Javascript -->
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/links.js?v={{ gs_globals['git_commit'] }}" id="ln-js" data-workset="{{ project }}"></script>
 <script src="/static/js/running_notes.js?v={{ gs_globals['git_commit'] }}" id="rn-js" data-project="{{project}}"></script>

--- a/run_dir/design/projects.html
+++ b/run_dir/design/projects.html
@@ -515,7 +515,7 @@ Description: Shows all presets configured for user and enables their selection.
 <script src="/static/js/jquery-ui.min.js"></script>
 <script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/bootstrap-datepicker.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/jQDateRangeSlider-min.js"></script>
 <script src="/static/js/projects.js?v={{ gs_globals['git_commit'] }}" id="projects-js"></script>
 {% end %}

--- a/run_dir/design/projects.html
+++ b/run_dir/design/projects.html
@@ -513,7 +513,6 @@ Description: Shows all presets configured for user and enables their selection.
 </div>
 
 <script src="/static/js/jquery-ui.min.js"></script>
-<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/bootstrap-datepicker.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/jQDateRangeSlider-min.js"></script>

--- a/run_dir/design/qpcr_pools.html
+++ b/run_dir/design/qpcr_pools.html
@@ -14,7 +14,6 @@ Description: Shows a table with all qPCR pools.
       <h1><span id="page_title">qPCR queues</span>
         <small class="text-muted">Showing all qPCR pools</small>
       </h1>
-      <button type="button" id="pools_copy_table_btn" class="btn btn-outline-dark"><span class="fa fa-copy"></span> Copy table</button>
       <button type="button" id="pools_copy_table" class="btn d-none" data-clipboard-target="#pools_table"></button>
       <label class="btn btn-outline-dark expand-all float-right mb-2"><span class="fa fa-plus-square" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="pools_table">
@@ -48,7 +47,6 @@ Description: Shows a table with all qPCR pools.
     </div>
 </div>
 
-<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/qpcr_pools.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>

--- a/run_dir/design/workset_queues.html
+++ b/run_dir/design/workset_queues.html
@@ -14,7 +14,6 @@ Description: Shows a table with extant workset queues.
       <h1><span id="page_title">Workset queues</span>
         <small class="text-muted">All samples that are available to be added to a workset in LIMS.</small>
       </h1>
-      <button type="button" id="samples_copy_table_btn" class="btn btn-outline-dark"><span class="fa fa-copy"></span> Copy table</button>
       <button type="button" id="samples_copy_table" class="btn d-none" data-clipboard-target="#samples_table"></button>
       <label class="btn btn-outline-dark expand-all float-right mb-2"><span class="fa fa-plus-square" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="samples_table">
@@ -48,8 +47,8 @@ Description: Shows a table with extant workset queues.
     </div>
 </div>
 
+<script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
 <script src="/static/js/clipboard.min.js"></script>
-<script src="/static/js/jquery.dataTables.min.js"></script>
 <script src="/static/js/workset_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/design/workset_queues.html
+++ b/run_dir/design/workset_queues.html
@@ -14,7 +14,6 @@ Description: Shows a table with extant workset queues.
       <h1><span id="page_title">Workset queues</span>
         <small class="text-muted">All samples that are available to be added to a workset in LIMS.</small>
       </h1>
-      <button type="button" id="samples_copy_table" class="btn d-none" data-clipboard-target="#samples_table"></button>
       <label class="btn btn-outline-dark expand-all float-right mb-2"><span class="fa fa-plus-square" aria-hidden="true"></span>Expand All</label>
       <table class="table table-hover table-striped table-bordered sortable" id="samples_table">
         <thead id="samples_table_head">

--- a/run_dir/design/workset_queues.html
+++ b/run_dir/design/workset_queues.html
@@ -47,7 +47,6 @@ Description: Shows a table with extant workset queues.
 </div>
 
 <script src="/static/js/dataTables-extensions-1.13.6.min.js"></script>
-<script src="/static/js/clipboard.min.js"></script>
 <script src="/static/js/workset_queues.js?v={{ gs_globals['git_commit'] }}"></script>
 <script src="/static/js/jquery-ui.min.js"></script>
 

--- a/run_dir/static/js/libpooling_queues.js
+++ b/run_dir/static/js/libpooling_queues.js
@@ -143,8 +143,3 @@ function init_listjs() {
 $('body').on('click', '.group', function(event) {
   $($("#libpools_table").DataTable().column(0).header()).trigger("click")
 });
-
-
-$('.dt-buttons > .buttons-copy').on('click', function () {
-  $('.expand-all').click();
-})

--- a/run_dir/static/js/libpooling_queues.js
+++ b/run_dir/static/js/libpooling_queues.js
@@ -79,6 +79,11 @@ function init_listjs() {
       "paging":false,
       "info":false,
       "order": [],
+      dom: 'Bfrti',
+      buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ],
       "drawCallback": function ( settings ) {
         var api = this.api();
         var rows = api.rows( {page:'current'} ).nodes();
@@ -93,6 +98,9 @@ function init_listjs() {
         });
       }
     });
+
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');
@@ -137,17 +145,7 @@ $('body').on('click', '.group', function(event) {
 });
 
 
-// Copy project samples table to clipboard
-var clipboard = new Clipboard('#libpools_copy_table');
-clipboard.on('success', function(e) {
-  e.clearSelection();
-  $('#libpools_copy_table_btn').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-  setTimeout(function(){
-    $('#libpools_copy_table_btn').removeClass('active').html('<span class="fa fa-copy"></span> Copy table');
-  }, 2000);
-});
-
-$('#libpools_copy_table_btn').on('click', function () {
+$('.dt-buttons > .buttons-copy').on('click', function () {
   $('.expand-all').click();
   $('#libpools_copy_table').click();
   $('.expand-all').click();

--- a/run_dir/static/js/libpooling_queues.js
+++ b/run_dir/static/js/libpooling_queues.js
@@ -147,6 +147,4 @@ $('body').on('click', '.group', function(event) {
 
 $('.dt-buttons > .buttons-copy').on('click', function () {
   $('.expand-all').click();
-  $('#libpools_copy_table').click();
-  $('.expand-all').click();
 })

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -25,15 +25,6 @@ $(document).ready(function() {
     e.preventDefault();
   });
 
-  // Copy project samples table to clipboard
-  var clipboard = new Clipboard('#proj_samples_copy_table');
-  clipboard.on('success', function(e) {
-    e.clearSelection();
-    $('#proj_samples_copy_table').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-    setTimeout(function(){
-      $('#proj_samples_copy_table').removeClass('active').html('<span class="fa fa-copy"></span> Copy table');
-    }, 2000);
-  });
   // Copy email address to clipboard and change the tooltip
   var email_clipboard = new Clipboard('.email_link a');
   email_clipboard.on('success', function(e) {

--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -110,7 +110,12 @@ function init_datatable() {
       "paging":false,
       "destroy": true,
       "info":false,
-      "order": [[ 0, "asc" ]]
+      "order": [[ 0, "asc" ]],
+      dom: 'Bfrti',
+      buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ]
     });
   //Add the bootstrap classes to the search thingy
   $('div.dataTables_filter input').addClass('form-control search search-query');
@@ -128,6 +133,8 @@ function init_datatable() {
           .draw();
       });
   });
+  $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+  $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 }
 
 ////////////////////////////////////

--- a/run_dir/static/js/projects.js
+++ b/run_dir/static/js/projects.js
@@ -204,11 +204,9 @@ function load_table(status, type, columns, dates) {
     $("#project_table_body").empty();
     var size = 0;
     undefined_fields=[];
-
-    $("#copyTable").html('<hr><button type="button" id="proj_table_copy_results" class="btn btn-sm btn-outline-dark" data-clipboard-target="#project_table"><span class="fa fa-copy"></span> Copy table to clipboard</button>');
     if ($('#user_presets_dropdown .dropdown-toggle').hasClass('active')){
       //only add sorting/filtering save button if user-defined preset is loaded
-      $("#copyTable").append('<button type="submit" class="btn btn-sm btn-primary float-right" id="saveFilter">Save filtering/sorting to Preset</button>').html();
+      $("#copyTable").append('<button type="submit" class="btn btn-sm btn-primary mt-3 float-right" id="saveFilter">Save filtering/sorting to Preset</button>').html();
     }
     $.each(data, function(project_id, summary_row) {
       $.each(summary_row, function(key,value){
@@ -394,6 +392,11 @@ function init_listjs(no_items, columns) {
           "destroy": true,
           "info":false,
           "order": [[ 0, "desc" ]],
+          dom: 'Bfrti',
+          buttons: [
+            { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+            { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+          ],
           "stateSave": true,
           "stateLoadCallback": function () {
           // read out the filter settings and apply
@@ -401,6 +404,8 @@ function init_listjs(no_items, columns) {
             }
         });
     }
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 
     //Add the bootstrap classes to the search thingy
     $('div.dataTables_filter input').addClass('form-control search search-query');

--- a/run_dir/static/js/projects.js
+++ b/run_dir/static/js/projects.js
@@ -1104,16 +1104,6 @@ function updateTableFields(order){
   }
 }
 
-// Copy project table to clipboard
-var clipboard = new Clipboard('#proj_table_copy_results');
-clipboard.on('success', function(e) {
-  e.clearSelection();
-  $('#proj_table_copy_results').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-  setTimeout(function(){
-    $('#proj_table_copy_results').removeClass('active').html('<span class="fa fa-copy"></span> Copy table to clipboard');
-  }, 2000);
-});
-
 $(document).keypress(function(e) {
   if ($("#settingsModal").hasClass('in') && (e.keycode == 13 || e.which == 13)) {
     $("#applySettingsModal").trigger('click');

--- a/run_dir/static/js/qpcr_pools.js
+++ b/run_dir/static/js/qpcr_pools.js
@@ -158,6 +158,8 @@ function init_listjs() {
       $('#pools_table').find('tr').find('table').css('visibility', reqText[$('.expand-all').text()][1]);
       $('.expand-all').contents().filter(function(){ return this.nodeType == 3; }).first().replaceWith(reqText[$('.expand-all').text()][0]);
     });
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 }
 
 $('body').on('click', '.group', function(event) {

--- a/run_dir/static/js/qpcr_pools.js
+++ b/run_dir/static/js/qpcr_pools.js
@@ -102,6 +102,11 @@ function init_listjs() {
       "paging":false,
       "info":false,
       "order": [],
+      dom: 'Bfrti',
+      buttons: [
+        { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+        { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+      ],
       "drawCallback": function ( settings ) {
         var api = this.api();
         var rows = api.rows( {page:'current'} ).nodes();
@@ -182,19 +187,3 @@ function getDaysAndDateLabel(date, option){
   }
    return [number_of_days, label];
 }
-
-// Copy project samples table to clipboard
-var clipboard = new Clipboard('#pools_copy_table');
-clipboard.on('success', function(e) {
-  e.clearSelection();
-  $('#pools_copy_table_btn').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-  setTimeout(function(){
-    $('#pools_copy_table_btn').removeClass('active').html('<span class="fa fa-copy"></span> Copy table');
-  }, 2000);
-});
-
-$('#pools_copy_table_btn').on('click', function () {
-  $('.expand-all').click();
-  $('#pools_copy_table').click();
-  $('.expand-all').click();
-})

--- a/run_dir/static/js/workset_queues.js
+++ b/run_dir/static/js/workset_queues.js
@@ -104,6 +104,11 @@ function init_listjs() {
         "paging":false,
         "destroy": true,
         "info":false,
+        dom: 'Bfrti',
+        buttons: [
+          { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
+          { extend: 'excel', className: 'btn btn-outline-dark mb-3' }
+        ],
         "drawCallback": function ( settings ) {
           var api = this.api();
           var rows = api.rows( {page:'current'} ).nodes();
@@ -134,6 +139,8 @@ function init_listjs() {
             .draw();
         } );
     } );
+    $(".dt-buttons > .buttons-copy").prepend("<span class='mr-1 fa fa-copy'>");
+    $(".dt-buttons > .buttons-excel").prepend("<span class='mr-1 fa fa-file-excel'>");
 }
 
 $('body').on('click', '.group', function(event) {
@@ -179,7 +186,7 @@ clipboard.on('success', function(e) {
   }, 2000);
 });
 
-$('#samples_copy_table_btn').on('click', function () {
+$('.dt-buttons > .buttons-copy').on('click', function () {
   $('.expand-all').click();
   $('#samples_copy_table').click();
   $('.expand-all').click();

--- a/run_dir/static/js/workset_queues.js
+++ b/run_dir/static/js/workset_queues.js
@@ -176,15 +176,6 @@ function getDaysAndDateLabel(date, option){
   return [number_of_days, label];
 }
 
-// Copy project samples table to clipboard
-var clipboard = new Clipboard('#samples_copy_table');
-clipboard.on('success', function(e) {
-  e.clearSelection();
-  $('#samples_copy_table_btn').addClass('active').html('<span class="fa fa-copy"></span> Copied!');
-  setTimeout(function(){
-    $('#samples_copy_table_btn').removeClass('active').html('<span class="fa fa-copy"></span> Copy table');
-  }, 2000);
-});
 
 $('.dt-buttons > .buttons-copy').on('click', function () {
   $('.expand-all').click();

--- a/run_dir/static/js/workset_queues.js
+++ b/run_dir/static/js/workset_queues.js
@@ -175,10 +175,3 @@ function getDaysAndDateLabel(date, option){
   }
   return [number_of_days, label];
 }
-
-
-$('.dt-buttons > .buttons-copy').on('click', function () {
-  $('.expand-all').click();
-  $('#samples_copy_table').click();
-  $('.expand-all').click();
-})


### PR DESCRIPTION
Added to:

- libpooling_queues.html
- project_samples.html
- projects.html
- workset_queues.html

I can't test the lib pooling queues and workset queues since we don't have the data. It should work in theory, right?

For the projects page, I kept the filtering saving button. I think the changes with the filtering should be done in a separate PR, since we wanted to implement more changes than just replace it.