### PR TITLE
Revert "Add colReorder to project samples page"

### DIFF
--- a/run_dir/static/js/project_samples.js
+++ b/run_dir/static/js/project_samples.js
@@ -103,7 +103,6 @@ function init_datatable() {
       "info":false,
       "order": [[ 0, "asc" ]],
       dom: 'Bfrti',
-      colReorder: true,
       buttons: [
         { extend: 'copy', className: 'btn btn-outline-dark mb-3' },
         { extend: 'excel', className: 'btn btn-outline-dark mb-3' }


### PR DESCRIPTION
Reverts SciLifeLab/genomics-status#792

The Caliper- and Fragment Analyzer images won't load after you have reordered a column. Will need to re-write a lot of code to get this working. 
We'll retract the PR for now.