### PR TITLE
ONT error handling

### DIFF
--- a/run_dir/design/flowcells.html
+++ b/run_dir/design/flowcells.html
@@ -9,10 +9,10 @@ Description: Shows a table with all flow cells.
 
 {% block stuff %}
 
-{% if errors %}
+{% if unfetched_runs %}
     <div class="alert alert-danger">
         <p>The following run(s) were not possible to be processed:</p>
-        {{", ".join(errors)}}
+        {{", ".join(unfetched_runs)}}
     </div>
 {% end %}
 

--- a/status/flowcell.py
+++ b/status/flowcell.py
@@ -351,6 +351,10 @@ def fetch_ont_run_stats(view_all, view_project, run_name):
         for metric in metrics:
             # Readable metrics, i.e. strings w. appropriate units
             unit = "" if "count" in metric else "bp"
+
+            if run_dict[metric] == "":
+                run_dict[metric] = 0
+
             run_dict["_".join([metric, "str"])] = add_prefix(
                 input_int=run_dict[metric], unit=unit
             )

--- a/status/flowcell.py
+++ b/status/flowcell.py
@@ -326,7 +326,7 @@ def fetch_ont_run_stats(view_all, view_project, run_name):
         run_dict["basecalled_bases"] = (
             run_dict["basecalled_pass_bases"] + run_dict["basecalled_fail_bases"]
         )
-        #TODO, somewhat temporary bugfix
+
         if run_dict["basecalled_pass_read_count"] <= 0:
             run_dict["accuracy"] = 0
         else:

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -5,6 +5,7 @@ import json
 import datetime
 import re
 import logging
+import traceback
 
 from dateutil.relativedelta import relativedelta
 from collections import OrderedDict
@@ -144,43 +145,48 @@ class FlowcellsHandler(SafeHandler):
 
         ont_flowcells = OrderedDict()
 
-        errors = []
+        unfetched_runs = []
         for row in view_all.rows:
             try:
                 ont_flowcells[row.key] = fetch_ont_run_stats(
                     view_all, view_project, row.key
                 )
-            except ValueError:
-                errors.append(row.key)
+            except Exception as e:
+                unfetched_runs.append(row.key)
+                application_log.error(f"Failed to fetch run {row.key}: {str(e)}\n{traceback.format_exc()}")
 
         if ont_flowcells:
-            # Use Pandas dataframe for column-wise operations, every db entry becomes a row
-            df = pd.DataFrame.from_dict(ont_flowcells, orient="index")
+            try:
+                # Use Pandas dataframe for column-wise operations, every db entry becomes a row
+                df = pd.DataFrame.from_dict(ont_flowcells, orient="index")
 
-            # Calculate ranks, to enable color coding
-            df["basecalled_pass_bases_Gbp_rank"] = (
-                df.basecalled_pass_bases_Gbp.rank() / len(df) * 100
-            ).apply(lambda x: round(x, 2))
-            df["n50_rank"] = (df.n50.rank() / len(df) * 100).apply(
-                lambda x: round(x, 2)
-            )
-            df["accuracy_rank"] = (df.accuracy.rank() / len(df) * 100).apply(
-                lambda x: round(x, 2)
-            )
+                # Calculate ranks, to enable color coding
+                df["basecalled_pass_bases_Gbp_rank"] = (
+                    df.basecalled_pass_bases_Gbp.rank() / len(df) * 100
+                ).apply(lambda x: round(x, 2))
+                df["n50_rank"] = (df.n50.rank() / len(df) * 100).apply(
+                    lambda x: round(x, 2)
+                )
+                df["accuracy_rank"] = (df.accuracy.rank() / len(df) * 100).apply(
+                    lambda x: round(x, 2)
+                )
 
-            # Empty values are replaced with empty strings
-            df.fillna("", inplace=True)
+                # Empty values are replaced with empty strings
+                df.fillna("", inplace=True)
 
-            # Convert back to dictionary and return
-            ont_flowcells = df.to_dict(orient="index")
-        return ont_flowcells, errors
+                # Convert back to dictionary and return
+                ont_flowcells = df.to_dict(orient="index")
+            except Exception as e:
+                application_log.error(f"Failed to compile ONT flowcell dataframe: {str(e)}\n{traceback.format_exc()}")
+
+        return ont_flowcells, unfetched_runs
 
     def get(self):
         # Default is to NOT show all flowcells
         all = self.get_argument("all", False)
         t = self.application.loader.load("flowcells.html")
         fcs = self.list_flowcells(all=all)
-        ont_fcs, errors = self.list_ont_flowcells()
+        ont_fcs, unfetched_runs = self.list_ont_flowcells()
         self.write(
             t.generate(
                 gs_globals=self.application.gs_globals,
@@ -191,7 +197,7 @@ class FlowcellsHandler(SafeHandler):
                 form_date=LatestRunningNoteHandler.formatDate,
                 find_id=find_id,
                 all=all,
-                errors=errors,
+                unfetched_runs=unfetched_runs,
             )
         )
 

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -5,7 +5,6 @@ import json
 import datetime
 import re
 import logging
-import traceback
 
 from dateutil.relativedelta import relativedelta
 from collections import OrderedDict
@@ -153,7 +152,7 @@ class FlowcellsHandler(SafeHandler):
                 )
             except Exception as e:
                 unfetched_runs.append(row.key)
-                application_log.error(f"Failed to fetch run {row.key}: {str(e)}\n{traceback.format_exc()}")
+                application_log.exception(f"Failed to fetch run {row.key}")
 
         if ont_flowcells:
             try:
@@ -177,7 +176,7 @@ class FlowcellsHandler(SafeHandler):
                 # Convert back to dictionary and return
                 ont_flowcells = df.to_dict(orient="index")
             except Exception as e:
-                application_log.error(f"Failed to compile ONT flowcell dataframe: {str(e)}\n{traceback.format_exc()}")
+                application_log.exception(f"Failed to compile ONT flowcell dataframe")
 
         return ont_flowcells, unfetched_runs
 

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -4,6 +4,7 @@
 import json
 import datetime
 import re
+import logging
 
 from dateutil.relativedelta import relativedelta
 from collections import OrderedDict
@@ -13,8 +14,10 @@ from genologics.config import BASEURI, USERNAME, PASSWORD
 import pandas as pd
 
 from status.util import SafeHandler
-from status.flowcell import FlowcellHandler, fetch_ont_run_stats
+from status.flowcell import fetch_ont_run_stats
 from status.running_notes import LatestRunningNoteHandler
+
+application_log = logging.getLogger("tornado.application")
 
 lims = lims.Lims(BASEURI, USERNAME, PASSWORD)
 


### PR DESCRIPTION
Fix so that ONT runs that cannot be successfully fetched are set aside, displayed on webpage and logged in the back-end.

Implement case-specific fix to prevent runs with no basecalling from crashing.