### PR TITLE
Updates to invoicing

### DIFF
--- a/run_dir/design/invoicing.html
+++ b/run_dir/design/invoicing.html
@@ -41,6 +41,7 @@ Description: Shows a table with projects that have had invoice specs generated b
                   <th class="sort">Project</th>
                   <th class="sort">Status</th>
                   <th class="sort">Time of Generation</th>
+                  <th class="sort">Total Cost</th>
                 </tr>
               </thead>
               <tbody id="invoicing_table_body">
@@ -60,12 +61,14 @@ Description: Shows a table with projects that have had invoice specs generated b
                       <tr class="sticky darkth">
                         <th class="sort">Project</th>
                         <th class="sort">Date of Download</th>
+                        <th class="sort">Total Cost</th>
                       </tr>
                     </thead>
                     <tfoot>
                       <tr class="darkth">
                         <th class="sort">Project</th>
                         <th class="sort">Date of Download</th>
+                        <th class="sort">Total Cost</th>
                       </tr>
                     </tfoot>
                     <tbody id="sent_invoices_table_body">

--- a/run_dir/static/js/invoicing.js
+++ b/run_dir/static/js/invoicing.js
@@ -11,7 +11,7 @@ $(document).ready(function() {
 });
 
 function load_invoicing_table() {
-  $("#invoicing_table_body").html('<tr><td colspan="4" class="text-muted"><span class="fa fa-sync fa-spin"></span> <em>Loading..</em></td></tr>');
+  $("#invoicing_table_body").html('<tr><td colspan="5" class="text-muted"><span class="fa fa-sync fa-spin"></span> <em>Loading..</em></td></tr>');
   return $.getJSON('/api/v1/invoice_spec_list', function(data) {
     $("#invoicing_table_body").empty()
     $('#invoicing_table').DataTable().clear().destroy()
@@ -24,8 +24,9 @@ function load_invoicing_table() {
       project_row += '<button type="button" id='+key+' class="btn btn-sm btn-outline-dark view_invoice_btn float-right px-3" data-toggle="modal" data-target="#displayInvoiceModal">View</button>'
       tbl_row.append($('<td>').html(project_row))
       tbl_row.append($('<td>').html('<h4 class="mb-0"><span class="badge '+badge_colour[value['project_status']]+'">'+value['project_status']+'</span></h4>'));
-      let date = new Date(parseInt(value['invoice_spec_generated']))
+      let date = new Date(parseInt(value['invoice_spec_generated']));
       tbl_row.append($('<td>').html(date.toISOString().slice(0,10) + ', ' + date.toISOString().slice(11,19)));
+      tbl_row.append($('<td>').html(value['total_cost'] + ' SEK' ));
       $("#invoicing_table_body").append(tbl_row)
     });
     // Initialise the Javascript sorting now that we know the number of rows
@@ -61,23 +62,31 @@ function init_listjs(table_name) {
       $(this).html( '<input size=10 type="text" placeholder="Search '+title+'" />' )
     } );
 
-
-    var table = $('#'+table_name).DataTable({
-        "paging":false,
-        "destroy": true,
-        "info":false,
-        "columnDefs": [ {
-            "orderable": false,
-            "defaultContent": '',
-            "data": null
-        } ]
-    });
+    let options = {
+      "paging":false,
+      "destroy": true,
+      "info":false,
+      "columnDefs": [ {
+          "orderable": false,
+          "defaultContent": '',
+          "data": null,
+      } ],
+    }
+    if(table_name==='invoicing_table'){
+      options['columns'] = [
+        null,
+        { "width": "25%" },
+        null,
+        null,
+        null
+      ]
+    }
+    var table = $('#'+table_name).DataTable(options);
     $('#'+table_name+'_filter label').remove();
     // Apply the search
     if(table_name!=='invoicing_table'){
       table.columns().every( function () {
           var that = this;
-          console.log(this.footer())
           $( 'input', this.footer() ).on( 'keyup change', function () {
               that
               .search( this.value )
@@ -135,7 +144,7 @@ $(".tabbable").on("click", '[role="tab"]', function() {
     load_invoicing_table()
   }
   if($(this).attr('href')=='#tab_sent_invoices'){
-    $("#sent_invoices_table_body").html('<tr><td colspan="2" class="text-muted"><span class="fa fa-sync fa-spin"></span> <em>Loading..</em></td></tr>');
+    $("#sent_invoices_table_body").html('<tr><td colspan="3" class="text-muted"><span class="fa fa-sync fa-spin"></span> <em>Loading..</em></td></tr>');
     return $.getJSON('/api/v1/get_sent_invoices', function(data) {
       $("#sent_invoices_table_body").empty();
       $.each(data, function(key, value) {
@@ -143,7 +152,8 @@ $(".tabbable").on("click", '[role="tab"]', function() {
           let project_row = '<a class="text-decoration-none" href="/project/'+key+'">'+key+'</a>'
           project_row += '<button type="button" id='+key+' class="btn btn-sm btn-outline-dark view_invoice_btn float-right px-3" data-toggle="modal" data-target="#displayInvoiceModal">View</button>'
           tbl_row.append($('<td>').html(project_row))
-          tbl_row.append($('<td>').html(value))
+          tbl_row.append($('<td>').html(value['downloaded_date']))
+          tbl_row.append($('<td>').html(value['total_cost'] + ' SEK'))
         $("#sent_invoices_table_body").append(tbl_row)
     });
    init_listjs('sent_invoices_table');

--- a/run_dir/static/js/pricing_main.js
+++ b/run_dir/static/js/pricing_main.js
@@ -412,7 +412,9 @@ const vPricingMain = {
             if (this.all_components !== null && this.all_products !== null) {
                 axios.post('/api/v1/pricing_validate_draft', {
                     components: this.all_components,
-                    products: this.all_products
+                    products: this.all_products, 
+                    //Will this break validation in the draft cost calculator?
+                    version: this.published_cost_calculator["Version"]
                 }).then(response => {
                     this.product_changes = response.data.changes['products']
                     this.component_changes = response.data.changes['components']

--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -453,7 +453,7 @@ app.component('v-pricing-quote', {
               <div class="fw-bold py-3">
                 Using cost calculator version {{ this.$root.published_cost_calculator["Version"] }} (published {{ new Date(this.$root.published_cost_calculator["Issued at"]).toLocaleString() }})
               </div>
-              <div v-if="latest_cost_calculator && this.$root.published_cost_calculator['Version']!== latest_cost_calculator['Version']" class="alert alert-danger" role="alert">
+              <div v-if="this.origin === 'Agreement' && this.$root.published_cost_calculator['Version']!== latest_cost_calculator['Version']" class="alert alert-danger" role="alert">
                 The latest cost calculator version is {{ this.latest_cost_calculator["Version"] }} (published {{ new Date(this.latest_cost_calculator["Issued at"]).toLocaleString() }})
               </div>
               <h4>Pricing Category</h4>

--- a/run_dir/static/js/pricing_quote.js
+++ b/run_dir/static/js/pricing_quote.js
@@ -19,7 +19,8 @@ app.component('v-pricing-quote', {
         loaded_timestamp: '',
         //added because the id wasn't displayed properly in loaded_version_desc otherwise
         proj_id: '',
-        agrm_save_success_msg:''
+        agrm_save_success_msg:'',
+        latest_cost_calculator: {}
       }
     },
     computed: {
@@ -160,6 +161,9 @@ app.component('v-pricing-quote', {
                       this.noQCProj = true
                     }
                     this.add_to_md_text()
+                    // Requires a wait to get the published_cost_calculator and only saved Agreements have the option to change cost calculator
+                    // so this can be here
+                    this.latest_cost_calculator = this.$root.published_cost_calculator
                 })
                 .catch(error => {
                     this.$root.error_messages.push('Unable to fetch project data, please try again or contact a system administrator.')
@@ -199,7 +203,12 @@ app.component('v-pricing-quote', {
         },
         timestamp_to_date(timestamp) {
           let date = new Date(parseInt(timestamp))
-          return date.toDateString() + ', ' + date.toLocaleTimeString(date)
+          // A shorter dateformat
+          return new Intl.DateTimeFormat("en-UK", {
+            year: "numeric",
+            month: "short",
+            day: "2-digit",
+          }).format(date) + ', ' + date.toLocaleTimeString(date)
         },
         load_saved_agreement(signed_timestamp){
           //Reset fields
@@ -227,6 +236,22 @@ app.component('v-pricing-quote', {
           if(timestamp_val!==""){
             this.loaded_timestamp = timestamp_val
             var sel_data = this.saved_agreement_data['saved_agreements'][timestamp_val]
+            if('cost_calculator_version' in sel_data){
+              if(this.$root.published_cost_calculator["Version"]!==sel_data['cost_calculator_version']){
+                axios
+                  .get('/api/v1/cost_calculator', {
+                    params: { version:  sel_data['cost_calculator_version'] }
+                  })
+                  .then(response => {
+                    this.$root.published_cost_calculator = response.data.cost_calculator
+                    this.$root.all_products = response.data.cost_calculator.products
+                    this.$root.all_components = response.data.cost_calculator.components
+                  })
+                  .catch(error => {
+                    this.$root.error_messages.push('Unable to fetch used cost calculator data, please try again or contact a system administrator.')
+                  })
+              }
+            }
             this.$root.price_type = sel_data['price_type']
             if('special_addition' in sel_data){
               this.$root.quote_special_additions = sel_data['special_addition']
@@ -399,6 +424,7 @@ app.component('v-pricing-quote', {
             agreement_data['products_included'] = this.$root.quote_prod_ids
           }
           agreement_data['exchange_rate_issued_date'] = this.$root.exch_rate_issued_at
+          agreement_data['cost_calculator_version'] =  this.$root.published_cost_calculator["Version"]
           this.submit_quote_form(agreement_data, type)
           if(type === 'save'){
             setTimeout(()=>{
@@ -426,6 +452,9 @@ app.component('v-pricing-quote', {
             <div class="col-5 status_limit_width_large">
               <div class="fw-bold py-3">
                 Using cost calculator version {{ this.$root.published_cost_calculator["Version"] }} (published {{ new Date(this.$root.published_cost_calculator["Issued at"]).toLocaleString() }})
+              </div>
+              <div v-if="latest_cost_calculator && this.$root.published_cost_calculator['Version']!== latest_cost_calculator['Version']" class="alert alert-danger" role="alert">
+                The latest cost calculator version is {{ this.latest_cost_calculator["Version"] }} (published {{ new Date(this.latest_cost_calculator["Issued at"]).toLocaleString() }})
               </div>
               <h4>Pricing Category</h4>
               <div class="form-radio" id="price_type_selector">
@@ -545,7 +574,7 @@ app.component('v-pricing-quote', {
                         <div class="form-check m-2">
                           <input class="form-check-input" type="radio" name="saved_agreements_radio" :id="timestamp" :value="timestamp" :checked="this.saved_agreement_data['signed']===timestamp">
                           <label class="form-check-label" :for="timestamp">
-                          <div v-bind:class="{ 'fw-bold' : timestamp === this.loaded_timestamp}"> {{ timestamp_to_date(timestamp) }}, {{ agreement['created_by']}} </div>
+                          <div v-bind:class="{ 'fw-bold' : timestamp === this.loaded_timestamp}"> {{ timestamp_to_date(timestamp) }}, {{ agreement['created_by']}} ({{ agreement['total_cost'] }} SEK on cost calc v{{ agreement['cost_calculator_version'] }})</div>
                           <p v-if="this.saved_agreement_data['signed']===timestamp" aria-hidden="true" class="m-2 text-danger fs-6">
                           <i class="far fa-file-signature fa-lg"></i>  Marked Signed {{ this.saved_agreement_data['signed_by'] }}, {{ timestamp_to_date(this.saved_agreement_data['signed_at']) }}</p>
                           <p v-if="this.saved_agreement_data['invoice_spec_generated_for']===timestamp" aria-hidden="true" class="m-2 text-success fs-6">

--- a/status/invoicing.py
+++ b/status/invoicing.py
@@ -79,6 +79,11 @@ class InvoicingPageDataHandler(AgreementsDBHandler):
 
         for row in view:
             proj_list[row.key] = row.value
+            agreement_data = self.fetch_agreement(row.key)
+            total_cost = agreement_data["saved_agreements"][
+                agreement_data["invoice_spec_generated_for"]
+            ]["total_cost"]
+            proj_list[row.key]["total_cost"] = total_cost
         self.write(proj_list)
 
 
@@ -358,15 +363,21 @@ class SentInvoiceHandler(AgreementsDBHandler):
     """
 
     def get(self):
-        six_months_ago = (datetime.datetime.now() - relativedelta(months=6)).strftime(
-            "%Y-%m-%d"
-        )
+        # Show all sent invoices for now.
+        # six_months_ago = (datetime.datetime.now() - relativedelta(months=6)).strftime(
+        #    "%Y-%m-%d"
+        # )
         view = self.application.projects_db.view(
-            "invoicing/spec_sent", startkey=six_months_ago
+            "invoicing/spec_sent",  # startkey=six_months_ago
         )
         proj_list = {}
         for row in view:
-            proj_list[row.value] = row.key
+            proj_list[row.value] = {"downloaded_date": row.key}
+            agreement_data = self.fetch_agreement(row.value)
+            total_cost = agreement_data["saved_agreements"][
+                agreement_data["invoice_spec_generated_for"]
+            ]["total_cost"]
+            proj_list[row.value]["total_cost"] = total_cost
         self.write(proj_list)
 
 

--- a/status/pricing.py
+++ b/status/pricing.py
@@ -406,7 +406,8 @@ class PricingValidateDraftDataHandler(PricingBaseHandler):
 
     def post(self):
         draft_content = tornado.escape.json_decode(self.request.body)
-        published_doc = self.fetch_published_doc_version()
+        version = draft_content.get("version", None)
+        published_doc = self.fetch_published_doc_version(version=version)
 
         validator = PricingValidator(draft_content, published_doc)
         validator.validate()
@@ -622,7 +623,9 @@ class PricingDataHandler(PricingBaseHandler):
 
         if no version is specified, the most recent published one is returned.
         """
-        version = self.get_argument("version", None)
+        version = None
+        if self.request.query:
+            version = int(self.request.query.split("version=")[1])
 
         doc = self.fetch_published_doc_version(version)
 
@@ -859,6 +862,9 @@ class SaveQuoteHandler(AgreementsDBHandler):
                 save_info["special_percentage"] = quote_input["special_percentage"]
             save_info["exchange_rate_issued_date"] = quote_input[
                 "exchange_rate_issued_date"
+            ]
+            save_info["cost_calculator_version"] = quote_input[
+                "cost_calculator_version"
             ]
             save_info["price_breakup"] = quote_input["price_breakup"]
             save_info["total_cost"] = quote_input["total_cost"]

--- a/status/projects.py
+++ b/status/projects.py
@@ -311,6 +311,10 @@ class ProjectsBaseDataHandler(SafeHandler):
             "project/summary_status", descending=True
         )
 
+        projects_with_agreements = self.application.agreements_db.view(
+            "project/project_id", descending=True
+        )
+
         # view_calls collects http requests to statusdb for each status requested
         view_calls = []
         if filter_projects[:1] != "P":
@@ -474,6 +478,9 @@ class ProjectsBaseDataHandler(SafeHandler):
                         final_projects[proj_id].get(start_date),
                         final_projects[proj_id].get(end_date),
                     )
+
+            if len(projects_with_agreements[proj_id]) > 0:
+                final_projects[proj_id]["has_agreements"] = True
 
         # Get Latest running note
         notes = self.application.running_notes_db.view(


### PR DESCRIPTION
- Take the cost calc version into account when saving and loading agreements
    - Save the current versoin of the cost calc when saving agreements
    - When loading agreements, load with the saved version of the cost calc instead of the latest version
- Display total cost in invoicing tables
- Add field 'Has Agreements' to project list to indicate projects that have agreements created.

Requires https://github.com/SciLifeLab/StatusDB_views/pull/164

Up on stage. (P24857 to test with, maybe)