### PR TITLE
Expand LIMS ID pattern matching for ONT FCs page

### DIFF
--- a/conda_requirements.yml
+++ b/conda_requirements.yml
@@ -1,6 +1,6 @@
 dependencies:
   - python=3.9
-  - anaconda::pango=1.42.0
+  - anaconda::pango>=1.42.0
   - anaconda::pandas>=1.3.2
   - conda-forge::psycopg2
   - conda-forge::open-fonts

--- a/run_dir/design/ont_flowcells.html
+++ b/run_dir/design/ont_flowcells.html
@@ -124,7 +124,7 @@
                                 stage
                             {% end %}
                             .scilifelab.se/clarity/work/
-                            {{ find_id(ont_flowcells[onefc]['experiment_name'], 'step') }}
+                            {{ find_id(ont_flowcells[onefc]['experiment_name'], 'step').split('-')[-1] }}
                             ">
                             {{ ont_flowcells[onefc]["experiment_name"] }}
                             </a>

--- a/run_dir/design/ont_flowcells.html
+++ b/run_dir/design/ont_flowcells.html
@@ -124,7 +124,7 @@
                                 stage
                             {% end %}
                             .scilifelab.se/clarity/work/
-                            {{ find_id(ont_flowcells[onefc]['experiment_name'], 'step')[-6:] }}
+                            {{ find_id(ont_flowcells[onefc]['experiment_name'], 'step') }}
                             ">
                             {{ ont_flowcells[onefc]["experiment_name"] }}
                             </a>

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -46,10 +46,10 @@ def find_id(stringable, pattern_type: str) -> re.match:
     string = str(stringable)
 
     patterns = {
-        "project": re.compile("P\d{5,6}"),
-        "sample": re.compile("P\d{5,6}_\d{3}"),
-        "pool": re.compile("2-\d{6}"),
-        "step": re.compile("24-\d{6}"),
+        "project": re.compile("P\d+"),
+        "sample": re.compile("P\d+_\d+"),
+        "pool": re.compile("2-\d+"),
+        "step": re.compile("24-\d+"),
     }
 
     match = re.match(patterns[pattern_type], string)

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -46,10 +46,10 @@ def find_id(stringable, pattern_type: str) -> re.match:
     string = str(stringable)
 
     patterns = {
-        "project": re.compile("P\d+"),
-        "sample": re.compile("P\d+_\d+"),
-        "pool": re.compile("2-\d+"),
-        "step": re.compile("24-\d+"),
+        "project": re.compile("P[1-9]\d{4,}"),
+        "sample": re.compile("P\d+_[1-9]\d{2,3}"),
+        "pool": re.compile("2-[1-9]\d{4,}"),
+        "step": re.compile("24-[1-9]\d{4,}"),
     }
 
     match = re.match(patterns[pattern_type], string)


### PR DESCRIPTION
The latest run demonstrated that fixed-length regex matching is no longer sustainable.

Tested locally.

Expanding version scope of `pango` dependency because `Conda` wouldn't allow me to create an environment otherwise.