### PR TITLE
Accomodate ONT runs w/o basecalling

### DIFF
--- a/run_dir/design/ont_flowcells.html
+++ b/run_dir/design/ont_flowcells.html
@@ -19,9 +19,9 @@
                 <th class="sort text-center" data-sort="flow_cell_qc">Flow cell QC</th>
                 <th class="sort text-center" data-sort="load_fmol">Loading (fmol)</th>
                 <th class="sort text-center" data-sort="reloadings">Reloadings</th>
-                <th class="sort text-center" data-sort="first_mux_loss">
+                <th class="sort text-center" data-sort="first_mux_vs_qc">
                     <abbr 
-                        data-toggle="tooltip" data-html="true" title="Fraction of pores lost between QC and first MUX scan">Initial Pore Loss (%)
+                        data-toggle="tooltip" data-html="true" title="Number of pores found at first MUX scan compared to QC">1st MUX scan vs QC (%)
                     </abbr>
                 </th>
                 <th class="sort text-center" data-sort="peak_pore_health">
@@ -58,7 +58,7 @@
                 <th class="sort" data-sort="flow_cell_qc"></th>
                 <th class="sort" data-sort="load_fmol"></th>
                 <th class="sort" data-sort="reloadings"></th>
-                <th class="sort" data-sort="first_mux_loss"></th>
+                <th class="sort" data-sort="first_mux_vs_qc"></th>
                 <th class="sort" data-sort="peak_pore_health"></th>
                 <th class="sort" data-sort="peak_pore_efficacy"></th>
                 <th class="sort" data-sort="t90"></th>
@@ -181,7 +181,7 @@
                     </td>
 
                     <td class="first_mux_loss text-center">
-                        {{ ont_flowcells[onefc].get("first_mux_loss_pc", "") }} 
+                        {{ ont_flowcells[onefc].get("first_mux_vs_qc", "") }} 
                     </td>
 
                     <td class="peak_pore_health text-center">
@@ -208,30 +208,13 @@
                         {% end %}
                     </td>
 
-                    <td class="basecalled_pass_bases_Gbp text-center
-
-                    {% if ont_flowcells[onefc]['basecalled_pass_bases_Gbp_rank'] != '' %}
-                        {% if ont_flowcells[onefc]['basecalled_pass_bases_Gbp_rank'] > 66.66 %}
-                            table-success
-                        {% elif ont_flowcells[onefc]['basecalled_pass_bases_Gbp_rank'] > 33.33 %}
-                            table-warning
-                        {% else %}
-                            table-danger
-                        {% end %}
-                    {% end %}">
+                    <td class="basecalled_pass_bases_Gbp text-center">
                         {{ ont_flowcells[onefc]["basecalled_pass_bases_Gbp"] }}
                     </td>
                     <td class="basecalled_pass_read_count_M text-center">{{ ont_flowcells[onefc]["basecalled_pass_read_count_M"] }}</td>
-                    <td class="n50_Kbp text-center
-                    {% if ont_flowcells[onefc]['n50_rank'] != '' %}
-                        {% if ont_flowcells[onefc]['n50_rank'] > 66.66 %}
-                            table-success
-                        {% elif ont_flowcells[onefc]['n50_rank'] > 33.33 %}
-                            table-warning
-                        {% else %}
-                            table-danger
-                        {% end %}
-                    {% end %}">{{ ont_flowcells[onefc]["n50_Kbp"] }}</td>
+                    <td class="n50_Kbp text-center">
+                        {{ ont_flowcells[onefc]["n50_Kbp"] }}
+                    </td>
                     <td class="accuracy text-center">{{ ont_flowcells[onefc]["accuracy"] }}</td>
                 </tr>
             {% end %}

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -138,6 +138,7 @@ class FlowcellsHandler(SafeHandler):
         view_all_stats = self.application.nanopore_runs_db.view(
             "info/all_stats", descending=True
         )
+        view_args = self.application.nanopore_runs_db.view("info/args", descending=True)
         view_project = self.application.projects_db.view(
             "project/id_name_dates", descending=True
         )
@@ -156,6 +157,7 @@ class FlowcellsHandler(SafeHandler):
                 ont_flowcells[row.key] = fetch_ont_run_stats(
                     run_name=row.key,
                     view_all_stats=view_all_stats,
+                    view_args=view_args,
                     view_project=view_project,
                     view_mux_scans=view_mux_scans,
                     view_pore_count_history=view_pore_count_history,

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -154,9 +154,9 @@ class FlowcellsHandler(SafeHandler):
         for row in view_all_stats.rows:
             try:
                 ont_flowcells[row.key] = fetch_ont_run_stats(
-                    run_name=row.key, 
-                    view_all_stats=view_all_stats, 
-                    view_project=view_project, 
+                    run_name=row.key,
+                    view_all_stats=view_all_stats,
+                    view_project=view_project,
                     view_mux_scans=view_mux_scans,
                     view_pore_count_history=view_pore_count_history,
                 )
@@ -168,17 +168,6 @@ class FlowcellsHandler(SafeHandler):
             try:
                 # Use Pandas dataframe for column-wise operations, every db entry becomes a row
                 df = pd.DataFrame.from_dict(ont_flowcells, orient="index")
-
-                # Calculate ranks, to enable color coding
-                df["basecalled_pass_bases_Gbp_rank"] = (
-                    df.basecalled_pass_bases_Gbp.rank() / len(df) * 100
-                ).apply(lambda x: round(x, 2))
-                df["n50_rank"] = (df.n50.rank() / len(df) * 100).apply(
-                    lambda x: round(x, 2)
-                )
-                df["accuracy_rank"] = (df.accuracy.rank() / len(df) * 100).apply(
-                    lambda x: round(x, 2)
-                )
 
                 # Empty values are replaced with empty strings
                 df.fillna("", inplace=True)
@@ -391,7 +380,7 @@ class FlowcellQCHandler(SafeHandler):
     def list_sample_runs(self, flowcell):
         lane_qc = OrderedDict()
         lane_view = self.application.flowcells_db.view("lanes/qc")
-        for row in lane_view[[flowcell, ""]:[flowcell, "Z"]]:
+        for row in lane_view[[flowcell, ""] : [flowcell, "Z"]]:
             lane_qc[row.key[1]] = row.value
 
         return lane_qc
@@ -410,7 +399,7 @@ class FlowcellDemultiplexHandler(SafeHandler):
     def lane_stats(self, flowcell):
         lane_qc = OrderedDict()
         lane_view = self.application.flowcells_db.view("lanes/demultiplex")
-        for row in lane_view[[flowcell, ""]:[flowcell, "Z"]]:
+        for row in lane_view[[flowcell, ""] : [flowcell, "Z"]]:
             lane_qc[row.key[1]] = row.value
 
         return lane_qc
@@ -430,7 +419,7 @@ class FlowcellQ30Handler(SafeHandler):
     def lane_q30(self, flowcell):
         lane_q30 = OrderedDict()
         lane_view = self.application.flowcells_db.view("lanes/gtq30", group_level=3)
-        for row in lane_view[[flowcell, ""]:[flowcell, "Z"]]:
+        for row in lane_view[[flowcell, ""] : [flowcell, "Z"]]:
             lane_q30[row.key[2]] = row.value["sum"] / row.value["count"]
 
         return lane_q30
@@ -529,7 +518,7 @@ class ReadsTotalHandler(SafeHandler):
                 data[row.key].append(row.value)
             # To check if sample is failed on lane level
             for row in bioinfo_view[
-                [query, None, None, None]:[f"{query}Z", "ZZ", "ZZ", "ZZ"]
+                [query, None, None, None] : [f"{query}Z", "ZZ", "ZZ", "ZZ"]
             ]:
                 if row.key[3] in data:
                     for fcl in data[row.key[3]]:


### PR DESCRIPTION
- Remove dataframe ranking calculations and subsequent coloring on GenStat. Colors can be re-implemented with fixed thresholds if requested.
- Accommodate runs without basecalling while still classifying them as finished
- Various reformatting