### PR TITLE
Highlight warnings last 24h for sensorpush and other changes for sensorpush

### DIFF
--- a/run_dir/design/sensorpush.html
+++ b/run_dir/design/sensorpush.html
@@ -1,9 +1,25 @@
 {% extends "base.html" %}
 {% block stuff %}
-  <h1 id="page_title" class="mb-5">Temperature info from Sensorpush</h1>
+  <h1 id="page_title" class="mb-2">Temperature info from Sensorpush</h1>
 
   <div class="mb-5 py-5 text-center">
-    <h2 class="mb-4">Summary of the last 24 hours</h2>
+    <div class="col-6 mx-auto">
+      <div class="mb-5 alert alert-danger py-3">
+      <h3>Sensors with warnings the last 24h</h3>
+      {% for sensor in sensor_24h_data.keys() %}
+        {% if sensor_24h_data[sensor]['intervals_higher'] %}
+          <h5> <a href="#header_sensor_{{sensor}}">{{sensor_24h_data[sensor]['sensor_name']}}</a> (too high)</h5>
+        {% end %}
+      {% end %}
+      {% for sensor in sensor_24h_data.keys() %}
+        {% if sensor_24h_data[sensor]['intervals_lower'] %}
+            <h5> <a href="#header_sensor_{{sensor}}">{{sensor_24h_data[sensor]['sensor_name']}}</a> (too low)</h5>
+        {% end %}
+      {% end %}
+      </div>
+    </div>
+
+    <h2 class="my-4">Summary of the last 24 hours</h2>
     <div id="loading_spinner" style="text-align:center; margin:100px 0;">
       <span class="fa fa-sync fa-spin"></span> Loading summary plots...
     </div>
@@ -23,9 +39,9 @@
   <h2 class="text-center">Details for each sensor from the last 4 weeks</h2>
   <div id="plots">
     {% for sensor in sensor_data.keys() %}
-    <div class="row" id='sensor_{{ sensor }}'>
+    <div class="row">
         <div class="col-auto">
-          <h2>
+          <h2 id='header_sensor_{{ sensor }}'>
             {{ sensor_data[sensor]['sensor_name'] }}
             {% if (sensor_data[sensor]['intervals_lower'] != []) or (sensor_data[sensor]['intervals_higher'] != []) %}
             <button class="btn btn-danger btn-lg ml-2" type="button" data-toggle="collapse" data-target="#intervals_{{sensor}}" aria-expanded="false" aria-controls="collapseExample">

--- a/run_dir/static/js/sensorpush.js
+++ b/run_dir/static/js/sensorpush.js
@@ -119,7 +119,7 @@ function plot_sum_data(){
                 type: 'datetime'
             },
             yAxis: {
-                title: { text: 'Temperature (C) of refridgerators' },
+                title: { text: 'Temperature (C) of refrigerators' },
                 tooltip: {
                     pointFormat: '<strong>{series.name}</strong>: {point.y:,.2f} C',
                 },

--- a/run_dir/static/js/sensorpush.js
+++ b/run_dir/static/js/sensorpush.js
@@ -124,7 +124,7 @@ function plot_sum_data(){
                     pointFormat: '<strong>{series.name}</strong>: {point.y:,.2f} C',
                 },
                 plotBands: [{
-                color: '#fff3cd',
+                color: '#f0f0f0',
                 from: 8,
                 width: 10,
                 to: 2
@@ -164,7 +164,7 @@ function plot_sum_data(){
                     pointFormat: '<strong>{series.name}</strong>: {point.y:,.2f} C',
                 },
                 plotBands: [{
-                color: '#fff3cd',
+                color: '#f0f0f0',
                 from: -10, 
                 width: 10, 
                 to: -33

--- a/run_dir/static/js/sensorpush.js
+++ b/run_dir/static/js/sensorpush.js
@@ -119,15 +119,15 @@ function plot_sum_data(){
                 type: 'datetime'
             },
             yAxis: {
-                title: { text: 'Temperature (C) of refrigerators' },
+                title: { text: 'Temperature (C) of refridgerators' },
                 tooltip: {
                     pointFormat: '<strong>{series.name}</strong>: {point.y:,.2f} C',
                 },
                 plotBands: [{
-                color: '#fdffd4',
-                from: 6,
+                color: '#fff3cd',
+                from: 8,
                 width: 10,
-                to: 0
+                to: 2
                 }]
             },
             legend: {
@@ -164,7 +164,7 @@ function plot_sum_data(){
                     pointFormat: '<strong>{series.name}</strong>: {point.y:,.2f} C',
                 },
                 plotBands: [{
-                color: '#fdffd4',
+                color: '#fff3cd',
                 from: -10, 
                 width: 10, 
                 to: -33

--- a/status/sensorpush.py
+++ b/status/sensorpush.py
@@ -114,6 +114,7 @@ class SensorpushHandler(SensorpushBaseHandler):
 
     def get(self):
         sensor_data = self.get_samples(start_days_ago=28)
+        sensor_24h_data = self.get_samples(start_days_ago=1)
 
         t = self.application.loader.load("sensorpush.html")
         self.write(
@@ -121,5 +122,6 @@ class SensorpushHandler(SensorpushBaseHandler):
                 gs_globals=self.application.gs_globals,
                 user=self.get_current_user(),
                 sensor_data=sensor_data,
+                sensor_24h_data=sensor_24h_data,
             )
         )


### PR DESCRIPTION
- Highlight warnings for last 24h so that it's easier to check the warnings reported on the index page
- Change limits for refridgerators to 2-8 degrees instead of 0-6. This corresponds to what the sensors are set to
- Change color for the band in the plot to grey instead of yellow.

Up on stage!