### PR TITLE
Change q30 threshold values on reads aggregation page

### DIFF
--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -57,25 +57,55 @@ Description: Summing tool for the reads
                     <tr class="darkth">
                         <th><a class="text-decoration-none" href="/project/{{ sample.split('_')[0] }}">{{ sample }}</a></th>
                         <th>%&nbsp;&gt;&nbsp;q30</th>
+                        <th>Mode</th>
+                        <th>Threshold</th>
                         <th>Add</th>
                         <th>{% if "isHiseqX" in readsdata %}Cluster{% else %}Reads{% end %}</th>
                     </tr>
                 {% for d in readsdata[sample] %}
+                    {% set run_setup = d['longer_read_length'] %}
+                    {% try %} {% set run_setup = int(run_setup) %} {% except %}{% end %}
                     <tr class="reads_data">
                         <td class="flowcell"><a class="text-decoration-none" href="/flowcells/{{ d['fcp'].split('_')[0] }}_{{ d['fcp'].split('_')[-1].split(':')[0] }}">{{ d['fcp'] }}</a></td>
                         {% if '_UD' not in d['fcp']  %}
-                            {% if d['q30'] is not None and d['q30']>75 %}
-                                <td class="table-success myq30">{{ d['q30'] }}</td>
-                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d.get('sample_status', '') != 'Failed' %} checked {% end %} /></td>
-                            {% elif d['q30'] is not None and d['q30']>30 %}
-                                <td class="table-warning myq30">{{ d['q30'] }}</td>
-                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
+                            {% if d['run_mode'] == 'HiSeq X' %}
+                                {% set q30_threshold = 75.0 %}
+                            {% elif 'MiSeq' in d['run_mode'] %}
+                                {% if run_setup >= 250 %}
+                                    {% set q30_threshold = 60.0 %}
+                                {% elif run_setup >= 150 %}
+                                    {% set q30_threshold = 70.0 %}
+                                {% elif run_setup >= 100 %}
+                                    {% set q30_threshold = 75.0 %}
+                                {% elif run_setup < 100 %}
+                                    {% set q30_threshold = 80.0 %}
+                                {% end %}
                             {% else %}
-                                <td class="table-danger myq30">{{ d['q30'] }}</td>
+                                {% if run_setup >= 250 %}
+                                    {% set q30_threshold = 60.0 %}
+                                {% elif run_setup >= 150 %}
+                                    {% set q30_threshold = 75.0 %}
+                                {% elif run_setup >= 100 %}
+                                    {% set q30_threshold = 80.0 %}
+                                {% elif run_setup < 100 %}
+                                    {% set q30_threshold = 85.0 %}
+                                {% end %}
+                            {% end %}
+                            {% if d['q30'] is not None and float(d['q30']) >= q30_threshold %}
+                                <td class="table-success myq30">{{ d['q30'] }}</td>
+                                <td>{{ run_setup }}</td>
+                                <td class="threshold">{{ q30_threshold }}</td>
+                                <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d.get('sample_status', '') != 'Failed' %} checked {% end %} /></td>
+                            {% else %}
+                                <td class="table-warning myq30">{{ d['q30'] }}</td>
+                                <td>{{ run_setup }}</td>
+                                <td>{{ q30_threshold }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                             {% end %}
                         {% else %}
                             <td class="myq30">{{ d['q30'] }}</td>
+                            <td>{{ run_setup }}</td>
+                            <td>{{ q30_threshold }}</td>
                             <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                         {% end %}
                         <td class="clusters">{{ d['cl'] }}</td>
@@ -83,6 +113,8 @@ Description: Summing tool for the reads
                 {% end %}
                     <tr class="darkth">
                         <th>Total</th>
+                        <th></th>
+                        <th></th>
                         <th></th>
                         <th class="sample_name">{{ sample }}</th>
                         <th id="{{ sample }}_total" class="reads_total"></th>

--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -84,7 +84,7 @@ Description: Summing tool for the reads
                         {% if '_UD' not in d['fcp']  %}
                             {% if d['run_mode'] == 'HiSeq X' %}
                                 {% set q30_threshold = threshold_dict['HiSeq X'] %}
-                                {% elif 'MiSeq' in d['run_mode'] %}
+                            {% elif 'MiSeq' in d['run_mode'] %}
                                 {% if run_setup >= 250 %}
                                     {% set q30_threshold = threshold_dict['MiSeq'][250] %}
                                 {% elif run_setup >= 150 %}
@@ -93,7 +93,7 @@ Description: Summing tool for the reads
                                     {% set q30_threshold = threshold_dict['MiSeq'][75] %}
                                 {% elif run_setup < 100 %}
                                     {% set q30_threshold = threshold_dict['MiSeq']['default'] %}
-                                {% end %}   
+                                {% end %}
                             {% else %}
                                 {% if run_setup >= 250 %}
                                     {% set q30_threshold = threshold_dict['default'][250] %}

--- a/run_dir/design/reads_total.html
+++ b/run_dir/design/reads_total.html
@@ -9,6 +9,22 @@ Description: Summing tool for the reads
 
 {% block stuff %}
 
+{% set threshold_dict = {
+    'HiSeq X': 75.0,
+    'MiSeq': {
+        250: 60.0,
+        150: 70.0,
+        100: 75.0,
+        'default': 80.0
+    },
+    'default': {
+        250: 60.0,
+        150: 75.0,
+        100: 80.0,
+        'default': 85.0
+    }
+} %}
+
 <div {% if readsdata %}style="margin-left: 270px;"{% end %}>
     <h1 id="page_title">Read Count Totals: <span id="rt_query">{{ query }}</span></h1>
     <div id="querybox">
@@ -57,8 +73,6 @@ Description: Summing tool for the reads
                     <tr class="darkth">
                         <th><a class="text-decoration-none" href="/project/{{ sample.split('_')[0] }}">{{ sample }}</a></th>
                         <th>%&nbsp;&gt;&nbsp;q30</th>
-                        <th>Mode</th>
-                        <th>Threshold</th>
                         <th>Add</th>
                         <th>{% if "isHiseqX" in readsdata %}Cluster{% else %}Reads{% end %}</th>
                     </tr>
@@ -69,43 +83,37 @@ Description: Summing tool for the reads
                         <td class="flowcell"><a class="text-decoration-none" href="/flowcells/{{ d['fcp'].split('_')[0] }}_{{ d['fcp'].split('_')[-1].split(':')[0] }}">{{ d['fcp'] }}</a></td>
                         {% if '_UD' not in d['fcp']  %}
                             {% if d['run_mode'] == 'HiSeq X' %}
-                                {% set q30_threshold = 75.0 %}
-                            {% elif 'MiSeq' in d['run_mode'] %}
+                                {% set q30_threshold = threshold_dict['HiSeq X'] %}
+                                {% elif 'MiSeq' in d['run_mode'] %}
                                 {% if run_setup >= 250 %}
-                                    {% set q30_threshold = 60.0 %}
+                                    {% set q30_threshold = threshold_dict['MiSeq'][250] %}
                                 {% elif run_setup >= 150 %}
-                                    {% set q30_threshold = 70.0 %}
+                                    {% set q30_threshold = threshold_dict['MiSeq'][150] %}
                                 {% elif run_setup >= 100 %}
-                                    {% set q30_threshold = 75.0 %}
+                                    {% set q30_threshold = threshold_dict['MiSeq'][75] %}
                                 {% elif run_setup < 100 %}
-                                    {% set q30_threshold = 80.0 %}
-                                {% end %}
+                                    {% set q30_threshold = threshold_dict['MiSeq']['default'] %}
+                                {% end %}   
                             {% else %}
                                 {% if run_setup >= 250 %}
-                                    {% set q30_threshold = 60.0 %}
+                                    {% set q30_threshold = threshold_dict['default'][250] %}
                                 {% elif run_setup >= 150 %}
-                                    {% set q30_threshold = 75.0 %}
+                                    {% set q30_threshold = threshold_dict['default'][150] %}
                                 {% elif run_setup >= 100 %}
-                                    {% set q30_threshold = 80.0 %}
+                                    {% set q30_threshold = threshold_dict['default'][100] %}
                                 {% elif run_setup < 100 %}
-                                    {% set q30_threshold = 85.0 %}
+                                    {% set q30_threshold = threshold_dict['default']['default'] %}
                                 {% end %}
                             {% end %}
                             {% if d['q30'] is not None and float(d['q30']) >= q30_threshold %}
                                 <td class="table-success myq30">{{ d['q30'] }}</td>
-                                <td>{{ run_setup }}</td>
-                                <td class="threshold">{{ q30_threshold }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}" {% if d.get('sample_status', '') != 'Failed' %} checked {% end %} /></td>
                             {% else %}
                                 <td class="table-warning myq30">{{ d['q30'] }}</td>
-                                <td>{{ run_setup }}</td>
-                                <td>{{ q30_threshold }}</td>
                                 <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                             {% end %}
                         {% else %}
                             <td class="myq30">{{ d['q30'] }}</td>
-                            <td>{{ run_setup }}</td>
-                            <td>{{ q30_threshold }}</td>
                             <td><input type='checkbox' class="reads_check" data-sfc="{{ sample+'_'+d['fcp'] }}"/></td>
                         {% end %}
                         <td class="clusters">{{ d['cl'] }}</td>
@@ -113,8 +121,6 @@ Description: Summing tool for the reads
                 {% end %}
                     <tr class="darkth">
                         <th>Total</th>
-                        <th></th>
-                        <th></th>
                         <th></th>
                         <th class="sample_name">{{ sample }}</th>
                         <th id="{{ sample }}_total" class="reads_total"></th>

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -15,8 +15,8 @@ function plot_summary_chart(data, sample_names){
         },
         plotOptions: {
             column: { stacking: 'normal',
-                      borderWidth: 0,
-                      groupPadding: 0.1
+                        borderWidth: 0,
+                        groupPadding: 0.1
                     },
             series: {
                 cursor: 'pointer',
@@ -49,9 +49,8 @@ function update_all_totals(){
     var ar_samples = Array();
     var ar_clusters = Array();
     var data = [
-        { name: 'q30>75', data: [], color: '#78b560'},
-        { name: '75>q30>30', data: [], color: '#e8cd4c'},
-        { name: '30>q30', data: [], color: '#f28e8e'},
+        { name: 'q30&gt;threshold', data: [], color: '#78b560'},
+        { name: 'q30&lt;threshold', data: [], color: '#e8cd4c'},
         { name: 'Not Selected', data: [], color: '#dddddd' }
     ];
     $(".reads_table").each(function(){
@@ -59,6 +58,7 @@ function update_all_totals(){
         var unchecked = 0;
         var w_q30 = 0;
         var s_name = $(this).find(".sample_name").text();
+        var threshold = parseInt($(this).find(".threshold").text());
         $(this).find(".reads_data").each(function(){
             var count = parseInt($(this).find(".clusters").text());
             if ($(this).find(".reads_check").prop("checked") == true){
@@ -75,20 +75,14 @@ function update_all_totals(){
         }
         ar_samples.push(s_name);
         ar_clusters.push(checked);
-        if (w_q30>75){
+        if (w_q30 >= threshold){
             data[0].data.push(checked);
             data[1].data.push(0);
-            data[2].data.push(0);
-        }else if (w_q30>30){
+        }else {
             data[1].data.push(checked);
             data[0].data.push(0);
-            data[2].data.push(0);
-        }else{
-            data[2].data.push(checked);
-            data[0].data.push(0);
-            data[2].data.push(0);
         }
-        data[3].data.push(unchecked);
+        data[2].data.push(unchecked);
         $(this).find(".reads_total").text(checked);
     });
     create_summary_table(ar_samples, ar_clusters);

--- a/run_dir/static/js/reads_total.js
+++ b/run_dir/static/js/reads_total.js
@@ -76,11 +76,11 @@ function update_all_totals(){
         ar_samples.push(s_name);
         ar_clusters.push(checked);
         if (w_q30 >= threshold){
-            data[0].data.push(checked);
-            data[1].data.push(0);
-        }else {
             data[1].data.push(checked);
             data[0].data.push(0);
+        }else {
+            data[0].data.push(checked);
+            data[1].data.push(0);
         }
         data[2].data.push(unchecked);
         $(this).find(".reads_total").text(checked);

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -542,25 +542,6 @@ class ReadsTotalHandler(SafeHandler):
                         if row.key[1] + ":" + row.key[2] == fcl["fcp"]:
                             fcl["sample_status"] = row.value["sample_status"]
                             break  # since the row is already found
-            #To add correct threshold values
-            for row in fc_view:
-                for lane, lane_data in row.value["lane_info"].items():
-                    for key, value in data.items():
-                        for lane_info in value:
-                            fcp_lane = ":" + lane
-                            if (
-                                query in lane_data["project_id"]
-                                and row.key[:6] in lane_info["fcp"]
-                                and row.key[-5:] in lane_info["fcp"]
-                                and fcp_lane in lane_info["fcp"]
-                            ):
-                                for i, item in enumerate(data[key]):
-                                    if item == lane_info:
-                                        item.update({
-                                            "run_mode": row.value["run_mode"],
-                                            "longer_read_length": row.value["longer_read_length"],
-                                        })
-                                        break
             for key in sorted(data.keys()):
                 ordereddata[key] = sorted(data[key], key=lambda d: d["fcp"])
             self.write(

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -510,14 +510,29 @@ class ReadsTotalHandler(SafeHandler):
                 )
             )
         else:
-            xfc_view = self.application.x_flowcells_db.view("samples/lane_clusters", reduce=False)
+            xfc_view = self.application.x_flowcells_db.view(
+                "samples/lane_clusters", reduce=False
+            )
             bioinfo_view = self.application.bioinfo_db.view("latest_data/sample_id")
-            fc_view = self.application.x_flowcells_db.view("info/summary", descending=True)
+            fc_view = self.application.x_flowcells_db.view(
+                "info/summary", descending=True
+            )
 
             for row in xfc_view[query : "{}Z".format(query)]:
                 if not row.key in data:
                     data[row.key] = []
+                # To add correct threshold values
+                fc_long_name = row.value["fcp"].split(":")[0]
+                fc_short_name = (
+                    fc_long_name.split("_")[0] + "_" + fc_long_name.split("_")[-1]
+                )
+                for info_row in fc_view[fc_short_name]:
+                    row.value["run_mode"] = info_row.value["run_mode"]
+                    row.value["longer_read_length"] = info_row.value[
+                        "longer_read_length"
+                    ]
                 data[row.key].append(row.value)
+
             # To check if sample is failed on lane level
             for row in bioinfo_view[
                 [query, None, None, None] : [f"{query}Z", "ZZ", "ZZ", "ZZ"]

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -529,24 +529,23 @@ class ReadsTotalHandler(SafeHandler):
                             break  # since the row is already found
             #To add correct threshold values
             for row in fc_view:
-                for x, y in row.items():
-                    for lane, dic in row.value["lane_info"].items():
-                        for key, value in data.items():
-                            for dicti in value:
-                                fcp_lane = ":" + lane
-                                if (
-                                    query in dic["project_id"]
-                                    and row.key[:6] in dicti["fcp"]
-                                    and row.key[-5:] in dicti["fcp"]
-                                    and fcp_lane in dicti["fcp"]
-                                ):
-                                    for i, item in enumerate(data[key]):
-                                        if item == dicti:
-                                            item.update({
-                                                "run_mode": row.value["run_mode"],
-                                                "longer_read_length": row.value["longer_read_length"],
-                                            })
-                                            break
+                for lane, lane_data in row.value["lane_info"].items():
+                    for key, value in data.items():
+                        for lane_info in value:
+                            fcp_lane = ":" + lane
+                            if (
+                                query in lane_data["project_id"]
+                                and row.key[:6] in lane_info["fcp"]
+                                and row.key[-5:] in lane_info["fcp"]
+                                and fcp_lane in lane_info["fcp"]
+                            ):
+                                for i, item in enumerate(data[key]):
+                                    if item == lane_info:
+                                        item.update({
+                                            "run_mode": row.value["run_mode"],
+                                            "longer_read_length": row.value["longer_read_length"],
+                                        })
+                                        break
             for key in sorted(data.keys()):
                 ordereddata[key] = sorted(data[key], key=lambda d: d["fcp"])
             self.write(

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -495,63 +495,68 @@ class ReadsTotalHandler(SafeHandler):
     """
 
     def get(self, query):
-        self.set_header("Content-type", "text/html")
-        template = self.application.loader.load("reads_total.html")
-
-        data = self.retrieve_data(query)
-        ordered_data = self.order_data(data)
-
-        self.write(
-            template.generate(
-                gs_globals=self.application.gs_globals,
-                user=self.get_current_user(),
-                readsdata=ordered_data,
-                query=query,
-            )
-        )
-
-    def retrieve_data(self, query):
-        xfc_view = self.application.x_flowcells_db.view("samples/lane_clusters", reduce=False)
-        bioinfo_view = self.application.bioinfo_db.view("latest_data/sample_id")
-        fc_view = self.application.x_flowcells_db.view("info/summary", descending=True)
-
         data = {}
-        for row in xfc_view[query : f"{query}Z"]:
-            data.setdefault(row.key, []).append(row.value)
-        # To check if sample is failed on lane level
-        for row in bioinfo_view[[query, None, None, None]:[f"{query}Z", "ZZ", "ZZ", "ZZ"]]:
-            for fcl in data.get(row.key[3], []):
-                if row.key[1] + ":" + row.key[2] == fcl["fcp"]:
-                    fcl["sample_status"] = row.value["sample_status"]
-                    break
-        #To add correct threshold values
-        for row in fc_view:
-            for x, y in row.items():
-                for lane, dic in row.value["lane_info"].items():
-                    for key, value in data.items():
-                        for dicti in value:
-                            fcp_lane = ":" + lane
-                            if (
-                                query in dic["project_id"]
-                                and row.key[:6] in dicti["fcp"]
-                                and row.key[-5:] in dicti["fcp"]
-                                and fcp_lane in dicti["fcp"]
-                            ):
-                                for i, item in enumerate(data[key]):
-                                    if item == dicti:
-                                        item.update({
-                                            "run_mode": row.value["run_mode"],
-                                            "longer_read_length": row.value["longer_read_length"],
-                                        })
-                                        break
+        ordereddata = OrderedDict()
+        self.set_header("Content-type", "text/html")
+        t = self.application.loader.load("reads_total.html")
 
-        return data
+        if not query:
+            self.write(
+                t.generate(
+                    gs_globals=self.application.gs_globals,
+                    user=self.get_current_user(),
+                    readsdata=ordereddata,
+                    query=query,
+                )
+            )
+        else:
+            xfc_view = self.application.x_flowcells_db.view("samples/lane_clusters", reduce=False)
+            bioinfo_view = self.application.bioinfo_db.view("latest_data/sample_id")
+            fc_view = self.application.x_flowcells_db.view("info/summary", descending=True)
 
-    def order_data(self, data):
-        ordered_data = OrderedDict()
-        for key in sorted(data.keys()):
-            ordered_data[key] = sorted(data[key], key=lambda d: d["fcp"])
-        return ordered_data
+            for row in xfc_view[query : "{}Z".format(query)]:
+                if not row.key in data:
+                    data[row.key] = []
+                data[row.key].append(row.value)
+            # To check if sample is failed on lane level
+            for row in bioinfo_view[
+                [query, None, None, None] : [f"{query}Z", "ZZ", "ZZ", "ZZ"]
+            ]:
+                if row.key[3] in data:
+                    for fcl in data[row.key[3]]:
+                        if row.key[1] + ":" + row.key[2] == fcl["fcp"]:
+                            fcl["sample_status"] = row.value["sample_status"]
+                            break  # since the row is already found
+            #To add correct threshold values
+            for row in fc_view:
+                for x, y in row.items():
+                    for lane, dic in row.value["lane_info"].items():
+                        for key, value in data.items():
+                            for dicti in value:
+                                fcp_lane = ":" + lane
+                                if (
+                                    query in dic["project_id"]
+                                    and row.key[:6] in dicti["fcp"]
+                                    and row.key[-5:] in dicti["fcp"]
+                                    and fcp_lane in dicti["fcp"]
+                                ):
+                                    for i, item in enumerate(data[key]):
+                                        if item == dicti:
+                                            item.update({
+                                                "run_mode": row.value["run_mode"],
+                                                "longer_read_length": row.value["longer_read_length"],
+                                            })
+                                            break
+            for key in sorted(data.keys()):
+                ordereddata[key] = sorted(data[key], key=lambda d: d["fcp"])
+            self.write(
+                t.generate(
+                    gs_globals=self.application.gs_globals,
+                    user=self.get_current_user(),
+                    readsdata=ordereddata,
+                    query=query,
+                )
+            )
 
 
 # Functions


### PR DESCRIPTION
As requested by Pär.

I cleaned up the python code a bit, hope that's ok.

I added "mode" and "threshold" values to the table, not sure if these are needed? I added them to easier derive the q30 colors.

I just added "q30>threshold" and "q30<threshold" metrics now. Do we want another limit value?

I'll deploy in stage. To see a project with q30 values below threshold, check P30702.

I'll also ask Pär if he's happy with it!