### PR TITLE
Add NGI Sweden website statistics page

### DIFF
--- a/run_dir/design/base.html
+++ b/run_dir/design/base.html
@@ -89,7 +89,7 @@
               <a class="dropdown-item" href="/ont_flowcells_plot">ONT Flowcells Trends</a>
               <a class="dropdown-item" href="/sensorpush">Sensorpush</a>
               <a class="dropdown-item" href="/lanes_ordered">Lanes Ordered</a>
-              <a class="dropdown-item" href="/run_dir/design/ngisweden_stats">NGI Sweden Website Statistics</a>
+              <a class="dropdown-item" href="/ngisweden_stats">NGI Sweden Website Statistics</a>
             </div>
           </li>
           {% if user and user.is_any_admin %}

--- a/run_dir/design/base.html
+++ b/run_dir/design/base.html
@@ -89,6 +89,7 @@
               <a class="dropdown-item" href="/ont_flowcells_plot">ONT Flowcells Trends</a>
               <a class="dropdown-item" href="/sensorpush">Sensorpush</a>
               <a class="dropdown-item" href="/lanes_ordered">Lanes Ordered</a>
+              <a class="dropdown-item" href="/run_dir/design/ngisweden_stats">NGI Sweden Website Statistics</a>
             </div>
           </li>
           {% if user and user.is_any_admin %}

--- a/run_dir/design/ngisweden_stats.html
+++ b/run_dir/design/ngisweden_stats.html
@@ -1,0 +1,16 @@
+{% extends 'base.html' %}
+{% block stuff %}
+
+<div class="container-fluid">
+    <h1>NGI Sweden Website Statistics</h1>
+    <p>Created with Looker Studio based on GA4 Data</p>
+    <br>
+    <div class="iframe-container">
+        <iframe src="https://lookerstudio.google.com/embed/reporting/4092d207-dc00-4123-bfb0-5dcc4588a8b5/page/GcJvD" 
+            frameborder="0" allowfullscreen 
+            sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox">
+        </iframe>
+    </div>
+</div>
+{% end %}
+

--- a/run_dir/design/ngisweden_stats.html
+++ b/run_dir/design/ngisweden_stats.html
@@ -5,12 +5,18 @@
     <h1>NGI Sweden Website Statistics</h1>
     <p>Created with Looker Studio based on GA4 Data</p>
     <br>
-    <div class="iframe-container">
-        <iframe src="https://lookerstudio.google.com/embed/reporting/4092d207-dc00-4123-bfb0-5dcc4588a8b5/page/GcJvD" 
-            frameborder="0" allowfullscreen 
-            sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox">
-        </iframe>
+    <div class="row">
+        <div class="col-md-12">
+            <div class="iframe-container">
+                <iframe src="https://lookerstudio.google.com/embed/reporting/4373b578-75f5-4bcf-8c9d-a64b5a92aea8/page/GcJvD"
+                    frameborder="0" allowfullscreen
+                    sandbox="allow-storage-access-by-user-activation allow-scripts allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                    id="reportFrame">
+                </iframe>
+            </div>
+        </div>
     </div>
 </div>
+
 {% end %}
 

--- a/run_dir/static/css/status_b5.css
+++ b/run_dir/static/css/status_b5.css
@@ -1256,7 +1256,7 @@ thead th.sort::before{
 .iframe-container {
     position: relative;
     width: 100%;
-    height: 100vh;
+    height: 1100px;
 }
 
 .iframe-container iframe {

--- a/run_dir/static/css/status_b5.css
+++ b/run_dir/static/css/status_b5.css
@@ -1250,3 +1250,20 @@ thead th.sort::before{
   top: -.1em;
   position: relative;
 }
+
+/* NGI Sweden stats */
+
+.iframe-container {
+    position: relative;
+    width: 100%;
+    height: 100vh;
+}
+
+.iframe-container iframe {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+    border: 0;
+}

--- a/status/ngisweden_stats.py
+++ b/status/ngisweden_stats.py
@@ -1,0 +1,15 @@
+from status.util import SafeHandler
+
+class NGISwedenHandler(SafeHandler):
+    """Handles the yield_plot page
+
+    Loaded through /ngisweden_stats
+    """
+
+    def get(self):
+        t = self.application.loader.load("ngisweden_stats.html")
+        self.write(
+            t.generate(
+                gs_globals=self.application.gs_globals, user=self.get_current_user()
+            )
+        )

--- a/status_app.py
+++ b/status_app.py
@@ -59,6 +59,7 @@ from status.invoicing import (
 )
 from status.lanes_ordered import LanesOrderedHandler, LanesOrderedDataHandler
 from status.multiqc_report import MultiQCReportHandler
+from status.ngisweden_stats import NGISwedenHandler
 from status.pricing import (
     PricingDateToVersionDataHandler,
     PricingExchangeRatesDataHandler,
@@ -352,6 +353,7 @@ class Application(tornado.web.Application):
             ("/lanes_ordered", LanesOrderedHandler),
             ("/libpooling_queues", LibraryPoolingQueuesHandler),
             ("/multiqc_report/([^/]*)$", MultiQCReportHandler),
+            ("/ngisweden_stats", NGISwedenHandler),
             ("/pools_qpcr", qPCRPoolsHandler),
             ("/pricing_preview", PricingPreviewHandler),
             ("/pricing_quote", PricingQuoteHandler),
@@ -535,6 +537,7 @@ class Application(tornado.web.Application):
             tornado.autoreload.watch("design/invoicing.html")
             tornado.autoreload.watch("design/barcode.html")
             tornado.autoreload.watch("design/link_tab.html")
+            tornado.autoreload.watch("design/ngisweden_stats.html")
             tornado.autoreload.watch("design/qpcr_pools.html")
             tornado.autoreload.watch("design/pricing_products.html")
             tornado.autoreload.watch("design/pricing_quote.html")


### PR DESCRIPTION
Created from GA4 data with Looker Studio. I have just done a first draft to be displayed during the dev meeting. It might change. I'll make it a WIP for that reason. 

We can use it to gain insights and improve the website.

Not sure why I have to add an API and Python handler to add a new page?

I'll put it up on stage.