### PR TITLE
Start using ibmcloudant sdk to slowly replace outdated CouchDB module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,6 +4,7 @@ ecdsa>=0.13
 genologics @ git+https://github.com/SciLifeLab/genologics.git
 genologics_sql @ git+https://github.com/SciLifeLab/genologics_sql.git
 httplib2>=0.10.3
+ibmcloudant>=0.9.1
 cffi
 matplotlib>=2.0.0
 markdown

--- a/status/suggestion_box.py
+++ b/status/suggestion_box.py
@@ -90,7 +90,7 @@ class SuggestionBoxHandler(SafeHandler):
                     source= "jira"
                     )
         
-        response = self.cloudant.post_document(db='suggestions_box', document=doc).get_result()
+        response = self.application.cloudant.post_document(db='suggestion_box', document=doc).get_result()
         
         if not response.get('ok'):
             self.set_status(500)

--- a/status_app.py
+++ b/status_app.py
@@ -10,6 +10,8 @@ import requests
 from collections import OrderedDict
 from couchdb import Server
 
+from ibmcloudant import cloudant_v1, CouchDbSessionAuthenticator
+
 import tornado.autoreload
 import tornado.httpserver
 import tornado.ioloop
@@ -419,6 +421,11 @@ class Application(tornado.web.Application):
         else:
             print(settings.get("couch_server", None))
             raise IOError("Cannot connect to couchdb")
+        
+        cloudant = cloudant_v1.CloudantV1(authenticator=CouchDbSessionAuthenticator(settings.get("username"), settings.get("password")))
+        cloudant.set_service_url(settings.get("couch_url"))
+        if cloudant:
+            self.cloudant = cloudant
 
         # Load columns and presets from genstat-defaults user in StatusDB
         genstat_id = ""


### PR DESCRIPTION
This seems to work for now but IBMCloudant sdk has the following disclaimer

> Disclaimer: This library is still a 0.x release. We do consider this library production-ready and capable, but there are still some limitations we’re working to resolve, and refinements we want to deliver. We are working really hard to minimise the disruption from now until the 1.0 release, but there may still be some changes that impact applications using this SDK. For now, be sure to pin versions to avoid surprises.

Not sure if we should pin a non-production version. We could wait for the 1.0 release to use it on the other scripts. 