### PR TITLE
Remove 10X Chromium and 10X Chromium: 5GEX (GEM-X) libraries from LibValidation qPCR queue

### DIFF
--- a/status/queues.py
+++ b/status/queues.py
@@ -69,6 +69,8 @@ class qPCRPoolsDataHandler(SafeHandler):
             "ONT cDNA PCR - RNA",
             "ONT direct cDNA - RNA",
             "ONT direct RNA - RNA",
+            "10X Chromium: 5GEX (GEM-X)",
+            "10X Chromium",
         ]
 
         queues = {}


### PR DESCRIPTION
As requested by Lina