### PR TITLE
Add Olink thresholds 

### DIFF
--- a/status/flowcell.py
+++ b/status/flowcell.py
@@ -22,6 +22,7 @@ thresholds = {
     "NovaSeqXPlus 10B": 1200,
     "NovaSeqXPlus 1.5B": 750,
     "NovaSeqXPlus 25B": 3000,
+    "NovaSeqXPlus Olink_NovaSeqX_1.5B_1Lib_V4": 562.5,
     "NextSeq Mid": 25,
     "NextSeq High": 75,
     "NextSeq 2000 P1": 100,

--- a/status/flowcell.py
+++ b/status/flowcell.py
@@ -23,6 +23,7 @@ thresholds = {
     "NovaSeqXPlus 1.5B": 750,
     "NovaSeqXPlus 25B": 3000,
     "NovaSeqXPlus Olink_NovaSeqX_1.5B_1Lib_V4": 562.5,
+    "NovaSeqXPlus Olink_NovaSeqX_10B_8Lib_V4": 900,
     "NextSeq Mid": 25,
     "NextSeq High": 75,
     "NextSeq 2000 P1": 100,


### PR DESCRIPTION
Add thresholds for Olink:
* 562.5M for Olink_NovaSeqX_1.5B_1Lib_V4 (75% of 750M threshold for 1.5B FCs)
* 900M for Olink_NovaSeqX_10B_8Lib_V4 (75% of 1200M threshold for 10B FCs)