### PR TITLE
Different views using date variable have differing formats for key

### DIFF
--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -104,7 +104,9 @@ class FlowcellsHandler(SafeHandler):
 
             if not all:
                 # With descending=True, end_key specifies where to stop
-                flowcell_status_view_params["end_key"] = [six_months_ago.replace("-", "")]
+                flowcell_status_view_params["end_key"] = [
+                    six_months_ago.replace("-", "")
+                ]
             # When all=True, fetch everything (no limit needed)
 
             flowcell_status_rows = (

--- a/status/flowcells.py
+++ b/status/flowcells.py
@@ -93,7 +93,7 @@ class FlowcellsHandler(SafeHandler):
         try:
             six_months_ago = (
                 datetime.datetime.now() - relativedelta(months=6)
-            ).strftime("%Y%m%d")
+            ).strftime("%Y-%m-%d")
 
             flowcell_status_view_params = {
                 "db": "flowcell_status",
@@ -104,7 +104,7 @@ class FlowcellsHandler(SafeHandler):
 
             if not all:
                 # With descending=True, end_key specifies where to stop
-                flowcell_status_view_params["end_key"] = [six_months_ago]
+                flowcell_status_view_params["end_key"] = [six_months_ago.replace("-", "")]
             # When all=True, fetch everything (no limit needed)
 
             flowcell_status_rows = (


### PR DESCRIPTION
Fix for MiSeq i100 values not showing up on Flowcells page. The reason I changed `six_months_ago` to account for demux_view_params rather flowcell_status_view_params is that its easier to take characters away than add it.